### PR TITLE
Remove both portnumber of connection and standard port

### DIFF
--- a/router/connection_maker.go
+++ b/router/connection_maker.go
@@ -153,9 +153,13 @@ func (cm *ConnectionMaker) checkStateAndAttemptConnections() time.Duration {
 	now := time.Now() // make sure we catch items just added
 	after := MaxDuration
 	for address, target := range cm.targets {
-		if our_connected_targets[address] {
-			delete(cm.targets, address)
-			continue
+		if host, _, err := net.SplitHostPort(address); err == nil {
+			normalized_addr := NormalisePeerAddr(host)
+			if our_connected_targets[address] || our_connected_targets[normalized_addr] {
+				delete(cm.targets, address)
+				delete(cm.targets, normalized_addr)
+				continue
+			}
 		}
 		if target.attempting {
 			continue


### PR DESCRIPTION
When adding targets for peers in `router/connection_maker.go`, both portnumber of connection and standard port are tried. So I think it might be better to remove both addresses when any one of them is connected? Otherwise, another target will always be re-trying.
