### PR TITLE
Move testing utils to its own package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ all: $(WEAVER_EXPORT) $(WEAVEDNS_EXPORT) $(WEAVETOOLS_EXPORT)
 update:
 	go get -u -f -v -tags -netgo ./$(dir $(WEAVER_EXE)) ./$(dir $(WEAVEDNS_EXE))
 
-$(WEAVER_EXE) $(WEAVEDNS_EXE):
+$(WEAVER_EXE) $(WEAVEDNS_EXE): common/*.go
 	go get -tags netgo ./$(@D)
 	go build -ldflags "-extldflags \"-static\" -X main.version $(WEAVE_VERSION)" -tags netgo -o $@ ./$(shell dirname $@)
 	@strings $@ | grep cgo_stub\\\.go >/dev/null || { \

--- a/nameserver/http_test.go
+++ b/nameserver/http_test.go
@@ -2,7 +2,7 @@ package nameserver
 
 import (
 	"fmt"
-	wt "github.com/zettio/weave/common"
+	wt "github.com/zettio/weave/testing"
 	"math/rand"
 	"net"
 	"net/http"

--- a/nameserver/mdns_client_test.go
+++ b/nameserver/mdns_client_test.go
@@ -2,7 +2,7 @@ package nameserver
 
 import (
 	"github.com/miekg/dns"
-	wt "github.com/zettio/weave/common"
+	wt "github.com/zettio/weave/testing"
 	"log"
 	"net"
 	"testing"

--- a/nameserver/mdns_server_test.go
+++ b/nameserver/mdns_server_test.go
@@ -2,7 +2,7 @@ package nameserver
 
 import (
 	"github.com/miekg/dns"
-	wt "github.com/zettio/weave/common"
+	wt "github.com/zettio/weave/testing"
 	"log"
 	"net"
 	"testing"

--- a/nameserver/zone_test.go
+++ b/nameserver/zone_test.go
@@ -1,7 +1,7 @@
 package nameserver
 
 import (
-	wt "github.com/zettio/weave/common"
+	wt "github.com/zettio/weave/testing"
 	"net"
 	"testing"
 )

--- a/testing/util.go
+++ b/testing/util.go
@@ -1,4 +1,4 @@
-package common
+package testing
 
 import (
 	"fmt"


### PR DESCRIPTION
So as not to pollute command-line flags with test.* options.

It appears that importing "testing" (from stdlib) will add flags. To
avoid this, we need code to not depend on testing. But, since
testing_utils was previously in the same package as the rest of the
code, it dragged testing in.

Renaming testing_util.go to e.g., nameserver/util_for_test.go might be enough to
avoid it being compiled with the regular code. We may want it to be
available to tests for other packages -- after all it is utilities for
testing -- so it goes in its own package.