### PR TITLE
cope with weavetools delays

### DIFF
--- a/weave
+++ b/weave
@@ -132,8 +132,6 @@ create_bridge() {
         ip link add name v${CONTAINER_IFNAME}du mtu $MTU type dummy
         ip link set dev v${CONTAINER_IFNAME}du master $BRIDGE
         ip link del dev v${CONTAINER_IFNAME}du
-        # disable offloading
-        run_tool host ethtool -K $BRIDGE tx off >/dev/null
         # Work around the situation where there are no rules allowing traffic
         # across our bridge. E.g. ufw
         add_iptables_rule filter FORWARD -i $BRIDGE -o $BRIDGE -j ACCEPT
@@ -141,6 +139,12 @@ create_bridge() {
         run_iptables -t nat -N WEAVE >/dev/null 2>&1 || true
         add_iptables_rule nat POSTROUTING -j WEAVE
     }
+    # disable offloading - we do this even when $BRIDGE already exists
+    # simply because it has the desirable side-effect of ensuring we
+    # have the $TOOLS_IMAGE and thus do not incur downloading-induced
+    # delays in more time-sensitive sections elsewhere.
+    run_tool host ethtool -K $BRIDGE tx off >/dev/null
+
     ip link set dev $BRIDGE up
 }
 

--- a/weavedns/Dockerfile
+++ b/weavedns/Dockerfile
@@ -3,4 +3,4 @@ MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /home/weave
 ADD ./weavedns /home/weave/
 EXPOSE 53/udp
-ENTRYPOINT ["/home/weave/weavedns", "-wait", "5"]
+ENTRYPOINT ["/home/weave/weavedns", "-wait", "20"]

--- a/weaver/Dockerfile
+++ b/weaver/Dockerfile
@@ -2,4 +2,4 @@ FROM scratch
 MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /home/weave
 ADD ./weaver /home/weave/
-ENTRYPOINT ["/home/weave/weaver", "-wait", "5"]
+ENTRYPOINT ["/home/weave/weaver", "-wait", "20"]


### PR DESCRIPTION
- ensure that we have the weavetools image downloaded before entering any time-critical sections, in particular post-container-startup network configuration
- in the weave router and dns containers, wait for longer for the ethwe interface to become available

Fixes #321.