### PR TITLE
Reform logging in weaveDNS

### DIFF
--- a/nameserver/http.go
+++ b/nameserver/http.go
@@ -24,7 +24,7 @@ func parseUrl(url string) (identifier string, ipaddr string, err error) {
 func httpErrorAndLog(level *log.Logger, w http.ResponseWriter, msg string,
 	status int, logmsg string, logargs ...interface{}) {
 	http.Error(w, msg, status)
-	level.Printf(logmsg, logargs...)
+	level.Printf("[http] "+logmsg, logargs...)
 }
 
 func ListenHttp(domain string, db Zone, port int) {
@@ -60,7 +60,7 @@ func ListenHttp(domain string, db Zone, port int) {
 			}
 
 			if dns.IsSubDomain(domain, name) {
-				Info.Printf("Adding %s -> %s", name, ipStr)
+				Info.Printf("[http] Adding %s -> %s", name, ipStr)
 				if err = db.AddRecord(ident, name, ip); err != nil {
 					if _, ok := err.(DuplicateError); !ok {
 						httpErrorAndLog(
@@ -70,7 +70,7 @@ func ListenHttp(domain string, db Zone, port int) {
 					} // oh, I already know this. whatever.
 				}
 			} else {
-				Info.Printf("Ignoring name %s, not in %s", name, domain)
+				Info.Printf("[http] Ignoring name %s, not in %s", name, domain)
 			}
 
 		case "DELETE":
@@ -85,7 +85,7 @@ func ListenHttp(domain string, db Zone, port int) {
 				reqError("Invalid IP in request", "Invalid IP in request: %s", ipStr)
 				return
 			}
-			Info.Printf("Deleting %s (%s)", ident, ipStr)
+			Info.Printf("[http] Deleting %s (%s)", ident, ipStr)
 			if err = db.DeleteRecord(ident, ip); err != nil {
 				if _, ok := err.(LookupError); !ok {
 					httpErrorAndLog(
@@ -103,6 +103,6 @@ func ListenHttp(domain string, db Zone, port int) {
 
 	address := fmt.Sprintf(":%d", port)
 	if err := http.ListenAndServe(address, nil); err != nil {
-		Error.Fatal("Unable to create http listener: ", err)
+		Error.Fatal("[http] Unable to create http listener: ", err)
 	}
 }

--- a/nameserver/mdns_lookup.go
+++ b/nameserver/mdns_lookup.go
@@ -10,10 +10,13 @@ func mdnsLookup(client *MDNSClient, name string, qtype uint16) (*Response, error
 	channel := make(chan *Response)
 	client.SendQuery(name, qtype, channel)
 	for resp := range channel {
-		Debug.Printf("Got response name %s addr %s", resp.Name, resp.Addr)
 		if err := resp.Err; err != nil {
+			Debug.Printf("[mdns] Error for query type %s name %d: %s",
+				dns.TypeToString[qtype], name, err)
 			return nil, err
 		} else {
+			Debug.Printf("[mdns] Got response name for query type %s name %s: name %s, addr %s",
+				dns.TypeToString[qtype], name, resp.Name, resp.Addr)
 			return resp, nil
 		}
 	}

--- a/nameserver/mdns_server.go
+++ b/nameserver/mdns_server.go
@@ -91,12 +91,15 @@ func (s *MDNSServer) makeHandler(qtype uint16, lookup LookupFunc) dns.HandlerFun
 			q := &r.Question[0]
 			if q.Qtype == qtype {
 				if m := lookup(s.zone, r, q); m != nil {
-					Debug.Printf("Found local answer to mDNS query %s", q.Name)
+					Debug.Printf("[mdns msgid %d] Found local answer to mDNS query %s",
+						r.MsgHdr.Id, q.Name)
 					if err := s.sendResponse(m); err != nil {
-						Warning.Printf("Error writing to %s", s.sendconn)
+						Warning.Printf("[mdns msgid %d] Error writing to %s",
+							r.MsgHdr.Id, s.sendconn)
 					}
 				} else {
-					Debug.Printf("No local answer for mDNS query %s", q.Name)
+					Debug.Printf("[mdns msgid %d] No local answer for mDNS query %s",
+						r.MsgHdr.Id, q.Name)
 				}
 			}
 		}

--- a/nameserver/mdns_server_test.go
+++ b/nameserver/mdns_server_test.go
@@ -34,7 +34,7 @@ func sendQuery(name string, querytype uint16) error {
 
 func TestServerSimpleQuery(t *testing.T) {
 	// The ff can be handy for debugging (obvs)
-	//wt.InitDefaultLogging(true)
+	wt.InitDefaultLogging(true)
 
 	log.Println("TestServerSimpleQuery starting")
 	var zone = new(ZoneDb)

--- a/nameserver/updater.go
+++ b/nameserver/updater.go
@@ -7,7 +7,8 @@ import (
 
 func checkError(err error, apiPath string) {
 	if err != nil {
-		Error.Fatalf("Unable to connect to Docker API on %s: %s", apiPath, err)
+		Error.Fatalf("[updater] Unable to connect to Docker API on %s: %s",
+			apiPath, err)
 	}
 }
 
@@ -22,7 +23,7 @@ func StartUpdater(apiPath string, zone Zone) error {
 	err = client.AddEventListener(events)
 	checkError(err, apiPath)
 
-	Info.Printf("Using Docker API on %s: %v", apiPath, env)
+	Info.Printf("[updater] Using Docker API on %s: %v", apiPath, env)
 
 	go func() {
 		for event := range events {
@@ -36,7 +37,7 @@ func handleEvent(zone Zone, event *docker.APIEvents, client *docker.Client) erro
 	switch event.Status {
 	case "die":
 		id := event.ID
-		Info.Printf("Container %s down. Removing records", id)
+		Info.Printf("[updater] Container %s down. Removing records", id)
 		zone.DeleteRecordsFor(id)
 	}
 	return nil

--- a/nameserver/zone.go
+++ b/nameserver/zone.go
@@ -76,7 +76,7 @@ func (zone *ZoneDb) ReverseLookupLocal(inaddr string) (string, error) {
 	if revIP := net.ParseIP(inaddr[:len(inaddr)-rdnsDomainLen]); revIP != nil {
 		revIP4 := revIP.To4()
 		ip := []byte{revIP4[3], revIP4[2], revIP4[1], revIP4[0]}
-		Debug.Printf("Looking for address: %+v", ip)
+		Debug.Printf("[zonedb] Looking for address: %+v", ip)
 		zone.mx.RLock()
 		defer zone.mx.RUnlock()
 		for _, r := range zone.recs {
@@ -86,7 +86,7 @@ func (zone *ZoneDb) ReverseLookupLocal(inaddr string) (string, error) {
 		}
 		return "", LookupError(inaddr)
 	} else {
-		Warning.Printf("Asked to reverse lookup %s", inaddr)
+		Warning.Printf("[zonedb] Asked to reverse lookup %s", inaddr)
 		return "", LookupError(inaddr)
 	}
 }


### PR DESCRIPTION
 * Put prefixes (including msg IDs) in front of log messages to
   distinguish them
 * Failed lookups get logged under Info as per issue #311
 * More accurate messages as per issue #311 

(and switch debug logging on during tests, just to be helpful)