### PR TITLE
Remove repeated 'iota' in const lists, since Go knows what you mean

### DIFF
--- a/nameserver/mdns_client.go
+++ b/nameserver/mdns_client.go
@@ -104,9 +104,9 @@ func LinkLocalMulticastListener(ifi *net.Interface) (net.PacketConn, error) {
 // ACTOR client API
 
 const (
-	CSendQuery       = iota
-	CShutdown        = iota
-	CMessageReceived = iota
+	CSendQuery = iota
+	CShutdown
+	CMessageReceived
 )
 
 type MDNSInteraction struct {

--- a/router/connection.go
+++ b/router/connection.go
@@ -123,10 +123,10 @@ func (conn *LocalConnection) log(args ...interface{}) {
 // ACTOR client API
 
 const (
-	CSendTCP          = iota
-	CSetEstablished   = iota
-	CSetRemoteUDPAddr = iota
-	CShutdown         = iota
+	CSendTCP = iota
+	CSetEstablished
+	CSetRemoteUDPAddr
+	CShutdown
 )
 
 // Async

--- a/router/connection_maker.go
+++ b/router/connection_maker.go
@@ -15,10 +15,10 @@ const (
 )
 
 const (
-	CMInitiate   = iota
-	CMTerminated = iota
-	CMRefresh    = iota
-	CMStatus     = iota
+	CMInitiate = iota
+	CMTerminated
+	CMRefresh
+	CMStatus
 )
 
 type ConnectionMaker struct {

--- a/router/consts.go
+++ b/router/consts.go
@@ -29,13 +29,13 @@ const (
 )
 
 const (
-	ProtocolConnectionEstablished  = iota
-	ProtocolFragmentationReceived  = iota
-	ProtocolStartFragmentationTest = iota
-	ProtocolNonce                  = iota
-	ProtocolFetchAll               = iota
-	ProtocolUpdate                 = iota
-	ProtocolPMTUVerified           = iota
+	ProtocolConnectionEstablished = iota
+	ProtocolFragmentationReceived
+	ProtocolStartFragmentationTest
+	ProtocolNonce
+	ProtocolFetchAll
+	ProtocolUpdate
+	ProtocolPMTUVerified
 )
 
 var (

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -113,10 +113,10 @@ func (peer *LocalPeer) CreateConnection(peerAddr string, acceptNewPeer bool) err
 // ACTOR client API
 
 const (
-	PAddConnection         = iota
-	PBroadcastTCP          = iota
-	PDeleteConnection      = iota
-	PConnectionEstablished = iota
+	PAddConnection = iota
+	PBroadcastTCP
+	PDeleteConnection
+	PConnectionEstablished
 )
 
 // Async: rely on the peer to shut us down if we shouldn't be adding


### PR DESCRIPTION
As mentioned at https://github.com/zettio/weave/pull/313/files#r22720060