### PR TITLE
Add tests for resolving names across hosts

### DIFF
--- a/test/200_dns_test.sh
+++ b/test/200_dns_test.sh
@@ -5,7 +5,7 @@
 C1=10.2.0.78
 C2=10.2.0.34
 
-start_suite "Resolve names"
+start_suite "Resolve names on a single host"
 
 run_on $HOST1 sudo $WEAVE stop || true
 run_on $HOST1 sudo $WEAVE stop-dns || true
@@ -14,9 +14,12 @@ run_on $HOST1 sudo $WEAVE launch-dns 10.0.0.2/8
 docker_on $HOST1 rm -f c1 c2 || true
 
 run_on $HOST1 sudo $WEAVE run $C2/24 -t --name=c2 -h seetwo.weave.local ubuntu
-run_on $HOST1 sudo $WEAVE run --with-dns $C1/24 -t --name=c1 ubuntu
+run_on $HOST1 sudo $WEAVE run --with-dns $C1/24 -t --name=c1 aanand/docker-dnsutils /bin/sh
 
-ok=$(docker -H tcp://$HOST1:2375 exec -i c1 sh -c "ping -q -c4 seetwo.weave.local >&2 && echo ok")
-assert "echo $ok" "ok"
+ok=$(docker -H tcp://$HOST1:2375 exec -i c1 sh -c "dig +short seetwo.weave.local")
+assert "echo $ok" "$C2"
+
+ok=$(docker -H tcp://$HOST1:2375 exec -i c1 sh -c "dig +short -x $C2")
+assert "echo $ok" "seetwo.weave.local."
 
 end_suite

--- a/test/210_dns_multicast_test.sh
+++ b/test/210_dns_multicast_test.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+. ./config.sh
+
+C1=10.2.3.78
+C2=10.2.3.34
+
+start_suite "Resolve names across hosts"
+
+for host in $HOST1 $HOST2; do
+    run_on $host sudo $WEAVE stop || true
+    run_on $host sudo $WEAVE stop-dns || true
+    docker_on $host rm -f c1 c2 || true
+done
+
+run_on $HOST1 sudo $WEAVE launch
+run_on $HOST2 sudo $WEAVE launch $HOST1
+
+run_on $HOST1 sudo $WEAVE launch-dns 10.0.0.2/8
+run_on $HOST2 sudo $WEAVE launch-dns 10.0.0.3/8
+
+run_on $HOST2 sudo $WEAVE run $C2/24 -t --name=c2 -h seetwo.weave.local ubuntu
+run_on $HOST1 sudo $WEAVE run --with-dns $C1/24 --name=c1 -t aanand/docker-dnsutils /bin/sh
+
+ok=$(docker -H tcp://$HOST1:2375 exec -i c1 dig +short seetwo.weave.local)
+assert "echo $ok" "$C2"
+
+ok=$(docker -H tcp://$HOST1:2375 exec -i c1 dig +short -x $C2)
+assert "echo $ok" "seetwo.weave.local."
+
+end_suite


### PR DESCRIPTION
It's more precise to use dig rather than ping. The stock ubuntu image
doesn't come with dig (in package dnsutils), but luckily Aanand made
an image which is exactly ubuntu+dnsutils.