### PR TITLE
better abstraction for protocol messages

### DIFF
--- a/router/connection.go
+++ b/router/connection.go
@@ -167,7 +167,7 @@ func (conn *LocalConnection) log(args ...interface{}) {
 // ACTOR client API
 
 const (
-	CSendTCP = iota
+	CSendProtocolMsg = iota
 	CSetEstablished
 	CReceivedHeartbeat
 	CShutdown
@@ -200,10 +200,10 @@ func (conn *LocalConnection) SetEstablished() {
 }
 
 // Async
-func (conn *LocalConnection) SendTCP(msg []byte) {
+func (conn *LocalConnection) SendProtocolMsg(tag ProtocolMsg, msg []byte) {
 	conn.queryChan <- &ConnectionInteraction{
-		Interaction: Interaction{code: CSendTCP},
-		payload:     msg}
+		Interaction: Interaction{code: CSendProtocolMsg},
+		payload:     TaggedProtocolMsg{tag, msg}}
 }
 
 // ACTOR server
@@ -265,16 +265,16 @@ func (conn *LocalConnection) queryLoop(queryChan <-chan *ConnectionInteraction) 
 				err = conn.handleReceivedHeartbeat(query.payload.(*net.UDPAddr))
 			case CSetEstablished:
 				err = conn.handleSetEstablished()
-			case CSendTCP:
-				err = conn.handleSendTCP(query.payload.([]byte))
+			case CSendProtocolMsg:
+				err = conn.handleSendProtocolMsg(query.payload.(TaggedProtocolMsg))
 			}
 		case <-tickerChan(conn.heartbeat):
 			conn.Forward(true, conn.heartbeatFrame, nil)
 		case <-tickerChan(conn.fetchAll):
-			err = conn.handleSendTCP(ProtocolFetchAllByte)
+			err = conn.handleSendSimpleProtocolMsg(ProtocolFetchAll)
 		case <-tickerChan(conn.fragTest):
 			conn.setStackFrag(false)
-			err = conn.handleSendTCP(ProtocolStartFragmentationTestByte)
+			err = conn.handleSendSimpleProtocolMsg(ProtocolStartFragmentationTest)
 		}
 	}
 	return
@@ -295,7 +295,7 @@ func (conn *LocalConnection) handleReceivedHeartbeat(remoteUDPAddr *net.UDPAddr)
 	conn.receivedHeartbeat = true
 	conn.Unlock()
 	if !old {
-		if err := conn.handleSendTCP(ProtocolConnectionEstablishedByte); err != nil {
+		if err := conn.handleSendSimpleProtocolMsg(ProtocolConnectionEstablished); err != nil {
 			return err
 		}
 	}
@@ -332,18 +332,22 @@ func (conn *LocalConnection) handleSetEstablished() error {
 	conn.fragTest = time.NewTicker(FragTestInterval)
 	// avoid initial waits for timers to fire
 	conn.Forward(true, conn.heartbeatFrame, nil)
-	if err := conn.handleSendTCP(ProtocolFetchAllByte); err != nil {
+	if err := conn.handleSendSimpleProtocolMsg(ProtocolFetchAll); err != nil {
 		return err
 	}
 	conn.setStackFrag(false)
-	if err := conn.handleSendTCP(ProtocolStartFragmentationTestByte); err != nil {
+	if err := conn.handleSendSimpleProtocolMsg(ProtocolStartFragmentationTest); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (conn *LocalConnection) handleSendTCP(msg []byte) error {
-	return conn.tcpSender.Send(msg)
+func (conn *LocalConnection) handleSendSimpleProtocolMsg(tag ProtocolMsg) error {
+	return conn.handleSendProtocolMsg(TaggedProtocolMsg{tag: tag})
+}
+
+func (conn *LocalConnection) handleSendProtocolMsg(m TaggedProtocolMsg) error {
+	return conn.tcpSender.Send(Concat([]byte{byte(m.tag)}, m.msg))
 }
 
 func (conn *LocalConnection) handleShutdown() {
@@ -564,13 +568,13 @@ func (conn *LocalConnection) receiveTCP(decoder *gob.Decoder) {
 			// payload is a subset of the receiver's topology, no
 			// further action is taken. Otherwise, the receiver sends
 			// out to all its connections an "improved" update.
-			conn.SendTCP(Concat(ProtocolUpdateByte, conn.Router.Peers.EncodeAllPeers()))
+			conn.SendProtocolMsg(ProtocolUpdate, conn.Router.Peers.EncodeAllPeers())
 		case ProtocolUpdate:
 			newUpdate, err := conn.Router.Peers.ApplyUpdate(payload)
 			if _, ok := err.(UnknownPeersError); err != nil && ok {
 				// That update contained a peer we didn't know about;
 				// request full update
-				conn.SendTCP(ProtocolFetchAllByte)
+				conn.SendProtocolMsg(ProtocolFetchAll, nil)
 				continue
 			}
 			if conn.CheckFatal(err) != nil {
@@ -579,7 +583,7 @@ func (conn *LocalConnection) receiveTCP(decoder *gob.Decoder) {
 			if len(newUpdate) != 0 {
 				conn.Router.ConnectionMaker.Refresh()
 				conn.Router.Routes.Recalculate()
-				conn.Router.Ourself.BroadcastTCP(Concat(ProtocolUpdateByte, newUpdate))
+				conn.Router.Ourself.SendProtocolMsg(ProtocolUpdate, newUpdate)
 			}
 		case ProtocolPMTUVerified:
 			conn.verifyPMTU <- int(binary.BigEndian.Uint16(payload))

--- a/router/connection.go
+++ b/router/connection.go
@@ -530,7 +530,7 @@ func (conn *LocalConnection) receiveTCP(decoder *gob.Decoder) {
 			continue
 		}
 		payload := msg[1:]
-		switch msg[0] {
+		switch ProtocolMsg(msg[0]) {
 		case ProtocolConnectionEstablished:
 			// We sent fast heartbeats to the remote peer, which has
 			// now received at least one of them and told us via this

--- a/router/consts.go
+++ b/router/consts.go
@@ -6,8 +6,6 @@ import (
 )
 
 const (
-	Protocol           = "weave"
-	ProtocolVersion    = 10
 	EthernetOverhead   = 14
 	UDPOverhead        = 28 // 20 bytes for IPv4, 8 bytes for UDP
 	Port               = 6783
@@ -28,24 +26,7 @@ const (
 	MaxDuration        = time.Duration(math.MaxInt64)
 )
 
-const (
-	ProtocolConnectionEstablished = iota
-	ProtocolFragmentationReceived
-	ProtocolStartFragmentationTest
-	ProtocolNonce
-	ProtocolFetchAll
-	ProtocolUpdate
-	ProtocolPMTUVerified
-)
-
 var (
-	FragTest                           = make([]byte, FragTestSize)
-	PMTUDiscovery                      = make([]byte, PMTUDiscoverySize)
-	ProtocolConnectionEstablishedByte  = []byte{ProtocolConnectionEstablished}
-	ProtocolFragmentationReceivedByte  = []byte{ProtocolFragmentationReceived}
-	ProtocolStartFragmentationTestByte = []byte{ProtocolStartFragmentationTest}
-	ProtocolNonceByte                  = []byte{ProtocolNonce}
-	ProtocolFetchAllByte               = []byte{ProtocolFetchAll}
-	ProtocolUpdateByte                 = []byte{ProtocolUpdate}
-	ProtocolPMTUVerifiedByte           = []byte{ProtocolPMTUVerified}
+	FragTest      = make([]byte, FragTestSize)
+	PMTUDiscovery = make([]byte, PMTUDiscoverySize)
 )

--- a/router/crypto.go
+++ b/router/crypto.go
@@ -85,7 +85,7 @@ func EncodeNonce(df bool) (*[24]byte, []byte, error) {
 		flags = flags | 1
 	}
 	SetNonceLow15Bits(&nonce, flags)
-	return &nonce, Concat(ProtocolNonceByte, nonce[:]), nil
+	return &nonce, nonce[:], nil
 }
 
 func DecodeNonce(msg []byte) (bool, *[24]byte) {
@@ -206,7 +206,7 @@ func (ne *NaClEncryptor) Bytes() []byte {
 		if err = ne.conn.CheckFatal(err); err != nil {
 			return []byte{}
 		}
-		ne.conn.SendTCP(encodedNonce)
+		ne.conn.SendProtocolMsg(ProtocolNonce, encodedNonce)
 		ne.nonce = freshNonce
 		nonce = freshNonce
 	}
@@ -225,7 +225,7 @@ func (ne *NaClEncryptor) Bytes() []byte {
 			return []byte{}
 		}
 		ne.nonceChan <- nonce
-		ne.conn.SendTCP(encodedNonce)
+		ne.conn.SendProtocolMsg(ProtocolNonce, encodedNonce)
 	}
 	ne.offset = offset
 

--- a/router/crypto.go
+++ b/router/crypto.go
@@ -207,7 +207,7 @@ func (ne *NaClEncryptor) Bytes() []byte {
 		if err = ne.conn.CheckFatal(err); err != nil {
 			return []byte{}
 		}
-		ne.conn.SendProtocolMsg(ProtocolNonce, encodedNonce)
+		ne.conn.SendProtocolMsg(ProtocolMsg{ProtocolNonce, encodedNonce})
 		ne.nonce = freshNonce
 		nonce = freshNonce
 	}
@@ -226,7 +226,7 @@ func (ne *NaClEncryptor) Bytes() []byte {
 			return []byte{}
 		}
 		ne.nonceChan <- nonce
-		ne.conn.SendProtocolMsg(ProtocolNonce, encodedNonce)
+		ne.conn.SendProtocolMsg(ProtocolMsg{ProtocolNonce, encodedNonce})
 	}
 	ne.offset = offset
 

--- a/router/crypto.go
+++ b/router/crypto.go
@@ -85,7 +85,8 @@ func EncodeNonce(df bool) (*[24]byte, []byte, error) {
 		flags = flags | 1
 	}
 	SetNonceLow15Bits(&nonce, flags)
-	return &nonce, nonce[:], nil
+	// NB: need to make a copy since callers may modify the array
+	return &nonce, Concat(nonce[:]), nil
 }
 
 func DecodeNonce(msg []byte) (bool, *[24]byte) {

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -250,7 +250,7 @@ func (peer *LocalPeer) handleConnectionEstablished(conn *LocalConnection) {
 
 func (peer *LocalPeer) handleSendProtocolMsg(m ProtocolMsg) {
 	peer.ForEachConnection(func(_ PeerName, conn Connection) {
-		conn.(*LocalConnection).SendProtocolMsg(m)
+		conn.(ProtocolSender).SendProtocolMsg(m)
 	})
 }
 

--- a/router/protocol.go
+++ b/router/protocol.go
@@ -21,3 +21,7 @@ type ProtocolMsg struct {
 	tag ProtocolTag
 	msg []byte
 }
+
+type ProtocolSender interface {
+	SendProtocolMsg(m ProtocolMsg)
+}

--- a/router/protocol.go
+++ b/router/protocol.go
@@ -1,0 +1,26 @@
+package router
+
+const (
+	Protocol        = "weave"
+	ProtocolVersion = 10
+)
+
+const (
+	ProtocolConnectionEstablished = iota
+	ProtocolFragmentationReceived
+	ProtocolStartFragmentationTest
+	ProtocolNonce
+	ProtocolFetchAll
+	ProtocolUpdate
+	ProtocolPMTUVerified
+)
+
+var (
+	ProtocolConnectionEstablishedByte  = []byte{ProtocolConnectionEstablished}
+	ProtocolFragmentationReceivedByte  = []byte{ProtocolFragmentationReceived}
+	ProtocolStartFragmentationTestByte = []byte{ProtocolStartFragmentationTest}
+	ProtocolNonceByte                  = []byte{ProtocolNonce}
+	ProtocolFetchAllByte               = []byte{ProtocolFetchAll}
+	ProtocolUpdateByte                 = []byte{ProtocolUpdate}
+	ProtocolPMTUVerifiedByte           = []byte{ProtocolPMTUVerified}
+)

--- a/router/protocol.go
+++ b/router/protocol.go
@@ -7,6 +7,11 @@ const (
 
 type ProtocolMsg byte
 
+type TaggedProtocolMsg struct {
+	tag ProtocolMsg
+	msg []byte
+}
+
 const (
 	ProtocolConnectionEstablished ProtocolMsg = iota
 	ProtocolFragmentationReceived
@@ -15,14 +20,4 @@ const (
 	ProtocolFetchAll
 	ProtocolUpdate
 	ProtocolPMTUVerified
-)
-
-var (
-	ProtocolConnectionEstablishedByte  = []byte{byte(ProtocolConnectionEstablished)}
-	ProtocolFragmentationReceivedByte  = []byte{byte(ProtocolFragmentationReceived)}
-	ProtocolStartFragmentationTestByte = []byte{byte(ProtocolStartFragmentationTest)}
-	ProtocolNonceByte                  = []byte{byte(ProtocolNonce)}
-	ProtocolFetchAllByte               = []byte{byte(ProtocolFetchAll)}
-	ProtocolUpdateByte                 = []byte{byte(ProtocolUpdate)}
-	ProtocolPMTUVerifiedByte           = []byte{byte(ProtocolPMTUVerified)}
 )

--- a/router/protocol.go
+++ b/router/protocol.go
@@ -5,8 +5,10 @@ const (
 	ProtocolVersion = 10
 )
 
+type ProtocolMsg byte
+
 const (
-	ProtocolConnectionEstablished = iota
+	ProtocolConnectionEstablished ProtocolMsg = iota
 	ProtocolFragmentationReceived
 	ProtocolStartFragmentationTest
 	ProtocolNonce
@@ -16,11 +18,11 @@ const (
 )
 
 var (
-	ProtocolConnectionEstablishedByte  = []byte{ProtocolConnectionEstablished}
-	ProtocolFragmentationReceivedByte  = []byte{ProtocolFragmentationReceived}
-	ProtocolStartFragmentationTestByte = []byte{ProtocolStartFragmentationTest}
-	ProtocolNonceByte                  = []byte{ProtocolNonce}
-	ProtocolFetchAllByte               = []byte{ProtocolFetchAll}
-	ProtocolUpdateByte                 = []byte{ProtocolUpdate}
-	ProtocolPMTUVerifiedByte           = []byte{ProtocolPMTUVerified}
+	ProtocolConnectionEstablishedByte  = []byte{byte(ProtocolConnectionEstablished)}
+	ProtocolFragmentationReceivedByte  = []byte{byte(ProtocolFragmentationReceived)}
+	ProtocolStartFragmentationTestByte = []byte{byte(ProtocolStartFragmentationTest)}
+	ProtocolNonceByte                  = []byte{byte(ProtocolNonce)}
+	ProtocolFetchAllByte               = []byte{byte(ProtocolFetchAll)}
+	ProtocolUpdateByte                 = []byte{byte(ProtocolUpdate)}
+	ProtocolPMTUVerifiedByte           = []byte{byte(ProtocolPMTUVerified)}
 )

--- a/router/protocol.go
+++ b/router/protocol.go
@@ -7,11 +7,6 @@ const (
 
 type ProtocolTag byte
 
-type ProtocolMsg struct {
-	tag ProtocolTag
-	msg []byte
-}
-
 const (
 	ProtocolConnectionEstablished ProtocolTag = iota
 	ProtocolFragmentationReceived
@@ -21,3 +16,8 @@ const (
 	ProtocolUpdate
 	ProtocolPMTUVerified
 )
+
+type ProtocolMsg struct {
+	tag ProtocolTag
+	msg []byte
+}

--- a/router/protocol.go
+++ b/router/protocol.go
@@ -5,15 +5,15 @@ const (
 	ProtocolVersion = 10
 )
 
-type ProtocolMsg byte
+type ProtocolTag byte
 
-type TaggedProtocolMsg struct {
-	tag ProtocolMsg
+type ProtocolMsg struct {
+	tag ProtocolTag
 	msg []byte
 }
 
 const (
-	ProtocolConnectionEstablished ProtocolMsg = iota
+	ProtocolConnectionEstablished ProtocolTag = iota
 	ProtocolFragmentationReceived
 	ProtocolStartFragmentationTest
 	ProtocolNonce

--- a/router/router.go
+++ b/router/router.go
@@ -308,12 +308,12 @@ func (router *Router) handleUDPPacketFunc(dec *EthernetDecoder, po PacketSink) F
 			case frameLen == EthernetOverhead+8:
 				relayConn.ReceivedHeartbeat(sender, binary.BigEndian.Uint64(frame[EthernetOverhead:]))
 			case frameLen == FragTestSize && bytes.Equal(frame, FragTest):
-				relayConn.SendTCP(ProtocolFragmentationReceivedByte)
+				relayConn.SendProtocolMsg(ProtocolFragmentationReceived, nil)
 			case frameLen == PMTUDiscoverySize && bytes.Equal(frame, PMTUDiscovery):
 			default:
 				frameLenBytes := []byte{0, 0}
 				binary.BigEndian.PutUint16(frameLenBytes, uint16(frameLen-EthernetOverhead))
-				relayConn.SendTCP(Concat(ProtocolPMTUVerifiedByte, frameLenBytes))
+				relayConn.SendProtocolMsg(ProtocolPMTUVerified, frameLenBytes)
 			}
 			return nil
 		}

--- a/router/router.go
+++ b/router/router.go
@@ -308,12 +308,12 @@ func (router *Router) handleUDPPacketFunc(dec *EthernetDecoder, po PacketSink) F
 			case frameLen == EthernetOverhead+8:
 				relayConn.ReceivedHeartbeat(sender, binary.BigEndian.Uint64(frame[EthernetOverhead:]))
 			case frameLen == FragTestSize && bytes.Equal(frame, FragTest):
-				relayConn.SendProtocolMsg(ProtocolFragmentationReceived, nil)
+				relayConn.SendProtocolMsg(ProtocolMsg{ProtocolFragmentationReceived, nil})
 			case frameLen == PMTUDiscoverySize && bytes.Equal(frame, PMTUDiscovery):
 			default:
 				frameLenBytes := []byte{0, 0}
 				binary.BigEndian.PutUint16(frameLenBytes, uint16(frameLen-EthernetOverhead))
-				relayConn.SendProtocolMsg(ProtocolPMTUVerified, frameLenBytes)
+				relayConn.SendProtocolMsg(ProtocolMsg{ProtocolPMTUVerified, frameLenBytes})
 			}
 			return nil
 		}


### PR DESCRIPTION
- Instead of representing protocol messages as []byte, represent them as instances of a ProtocolMsg struct, containing a ProtocolTag identifying the message type, and a []byte for the payload.
- Introduce ProtocolSender interface, containing a SendProtocolMsg method. This is implemented by LocalConnection and LocalPeer, replacing the former SendTCP/BroadcastTCP methods. In the former case the ProtocolMsg is sent to the peer at the other end of the connection, in the latter case it is sent to all peers the local peer is connected to.