### PR TITLE
Obtain status info in JSON format

### DIFF
--- a/router/json.go
+++ b/router/json.go
@@ -6,13 +6,15 @@ import (
 	"time"
 )
 
-func (router *Router) MarshalJSON() ([]byte, error) {
+func (router *Router) GenerateStatusJSON(version, encryption string) ([]byte, error) {
 	return json.Marshal(struct {
+		Version         string
+		Encryption      string
 		Name, Interface string
 		Macs            *MacCache
 		Peers           *Peers
 		Routes          *Routes
-	}{router.Ourself.Name.String(), fmt.Sprintf("%v", router.Iface), router.Macs, router.Peers, router.Routes})
+	}{version, encryption, router.Ourself.Name.String(), fmt.Sprintf("%v", router.Iface), router.Macs, router.Peers, router.Routes})
 	// leaving out ConectionMaker due to async complexities
 }
 

--- a/router/json.go
+++ b/router/json.go
@@ -1,0 +1,78 @@
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+func (router *Router) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Name, Interface string
+		Macs            *MacCache
+		Peers           *Peers
+		Routes          *Routes
+	}{router.Ourself.Name.String(), fmt.Sprintf("%v", router.Iface), router.Macs, router.Peers, router.Routes})
+	// leaving out ConectionMaker due to async complexities
+}
+
+func (cache *MacCache) MarshalJSON() ([]byte, error) {
+	type cacheEntry struct {
+		Mac      string
+		PeerName PeerName
+		LastSeen time.Time
+	}
+	entries := make([]*cacheEntry, 0)
+	for key, entry := range cache.table {
+		entries = append(entries, &cacheEntry{intmac(key).String(), entry.peer.Name, entry.lastSeen})
+	}
+	return json.Marshal(entries)
+}
+
+func (peers *Peers) MarshalJSON() ([]byte, error) {
+	ps := make([]*Peer, 0)
+	peers.ForEach(func(_ PeerName, peer *Peer) { ps = append(ps, peer) })
+	return json.Marshal(ps)
+}
+
+func (routes *Routes) MarshalJSON() ([]byte, error) {
+	routes.RLock()
+	defer routes.RUnlock()
+	type uni struct {
+		Dest, Via PeerName
+	}
+	type broad struct {
+		Source PeerName
+		Via    []PeerName
+	}
+	var r struct {
+		Unicast   []*uni
+		Broadcast []*broad
+	}
+	for name, hop := range routes.unicast {
+		r.Unicast = append(r.Unicast, &uni{name, hop})
+	}
+	for name, hops := range routes.broadcast {
+		r.Broadcast = append(r.Broadcast, &broad{name, hops})
+	}
+	return json.Marshal(r)
+}
+
+func (peer *Peer) MarshalJSON() ([]byte, error) {
+	conns := make([]Connection, 0)
+	peer.ForEachConnection(func(remoteName PeerName, conn Connection) {
+		conns = append(conns, conn)
+	})
+	return json.Marshal(struct {
+		Name        string
+		Connections []Connection
+	}{peer.Name.String(), conns})
+}
+
+func (conn *RemoteConnection) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct{ RemoteName, TcpAddr string }{conn.Remote().Name.String(), conn.RemoteTCPAddr()})
+}
+
+func (name PeerName) MarshalJSON() ([]byte, error) {
+	return json.Marshal(name.String())
+}

--- a/router/json.go
+++ b/router/json.go
@@ -65,8 +65,10 @@ func (peer *Peer) MarshalJSON() ([]byte, error) {
 	})
 	return json.Marshal(struct {
 		Name        string
+		UID         uint64
+		Version     uint64
 		Connections []Connection
-	}{peer.Name.String(), conns})
+	}{peer.Name.String(), peer.UID, peer.version, conns})
 }
 
 func (conn *RemoteConnection) MarshalJSON() ([]byte, error) {

--- a/weaver/main.go
+++ b/weaver/main.go
@@ -145,6 +145,11 @@ func handleHttp(router *weave.Router) {
 		io.WriteString(w, fmt.Sprintln("Encryption", encryption))
 		io.WriteString(w, router.Status())
 	})
+	http.HandleFunc("/status-json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		json, _ := router.MarshalJSON()
+		w.Write(json)
+	})
 	http.HandleFunc("/connect", func(w http.ResponseWriter, r *http.Request) {
 		peer := r.FormValue("peer")
 		if addr, err := net.ResolveTCPAddr("tcp4", weave.NormalisePeerAddr(peer)); err == nil {

--- a/weaver/main.go
+++ b/weaver/main.go
@@ -146,7 +146,6 @@ func handleHttp(router *weave.Router) {
 		io.WriteString(w, router.Status())
 	})
 	http.HandleFunc("/status-json", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 		json, _ := router.MarshalJSON()
 		w.Write(json)
 	})

--- a/weaver/main.go
+++ b/weaver/main.go
@@ -146,7 +146,7 @@ func handleHttp(router *weave.Router) {
 		io.WriteString(w, router.Status())
 	})
 	http.HandleFunc("/status-json", func(w http.ResponseWriter, r *http.Request) {
-		json, _ := router.MarshalJSON()
+		json, _ := router.GenerateStatusJSON(version, encryption)
 		w.Write(json)
 	})
 	http.HandleFunc("/connect", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Json generation is done by creating dummy structs and arrays that match the format we want, copying the information into them, then getting Go's standard json encoder to do the work.

All the implementation is pulled into one file json.go rather than scattering it across all the relevant implementations; at time of writing this seems easier to grasp.