### PR TITLE
Tear down connections on prolonged loss of UDP heartbeat

### DIFF
--- a/router/consts.go
+++ b/router/consts.go
@@ -6,24 +6,26 @@ import (
 )
 
 const (
-	EthernetOverhead   = 14
-	UDPOverhead        = 28 // 20 bytes for IPv4, 8 bytes for UDP
-	Port               = 6783
-	HttpPort           = Port + 1
-	DefaultPMTU        = 65535
-	MaxUDPPacketSize   = 65536
-	ChannelSize        = 16
-	UDPNonceSendAt     = 8192
-	FragTestSize       = 60001
-	PMTUDiscoverySize  = 60000
-	FastHeartbeat      = 500 * time.Millisecond
-	SlowHeartbeat      = 10 * time.Second
-	FragTestInterval   = 5 * time.Minute
-	EstablishedTimeout = 30 * time.Second
-	ReadTimeout        = 1 * time.Minute
-	PMTUVerifyAttempts = 8
-	PMTUVerifyTimeout  = 10 * time.Millisecond // gets doubled with every attempt
-	MaxDuration        = time.Duration(math.MaxInt64)
+	EthernetOverhead    = 14
+	UDPOverhead         = 28 // 20 bytes for IPv4, 8 bytes for UDP
+	Port                = 6783
+	HttpPort            = Port + 1
+	DefaultPMTU         = 65535
+	MaxUDPPacketSize    = 65536
+	ChannelSize         = 16
+	UDPNonceSendAt      = 8192
+	FragTestSize        = 60001
+	PMTUDiscoverySize   = 60000
+	FastHeartbeat       = 500 * time.Millisecond
+	SlowHeartbeat       = 10 * time.Second
+	FragTestInterval    = 5 * time.Minute
+	EstablishedTimeout  = 30 * time.Second
+	ReadTimeout         = 1 * time.Minute
+	PMTUVerifyAttempts  = 8
+	PMTUVerifyTimeout   = 10 * time.Millisecond // gets doubled with every attempt
+	MaxDuration         = time.Duration(math.MaxInt64)
+	MaxMissedHeartbeats = 3
+	HeartbeatTimeout    = MaxMissedHeartbeats * SlowHeartbeat
 )
 
 var (

--- a/router/consts.go
+++ b/router/consts.go
@@ -19,7 +19,6 @@ const (
 	FastHeartbeat       = 500 * time.Millisecond
 	SlowHeartbeat       = 10 * time.Second
 	FragTestInterval    = 5 * time.Minute
-	EstablishedTimeout  = 30 * time.Second
 	ReadTimeout         = 1 * time.Minute
 	PMTUVerifyAttempts  = 8
 	PMTUVerifyTimeout   = 10 * time.Millisecond // gets doubled with every attempt


### PR DESCRIPTION
Addresses #373 - detect udp connectivity breakage.

Once a connection moves to the established state indicating that the remote peer has received one of our heartbeats a timer is started. If we do not receive a UDP heartbeat from the remote peer within this time (default is three times the slow heartbeat interval) the connection is terminated:

    connection shutting down due to error: timed out waiting for UDP heartbeat

At this point the existing connection resumption mechanism takes over. In normal operation, the timer is reset each time we receive a heartbeat.

Implementation notes:

* It would be possible to merge `establishedTimeout` and `heartbeatTimeout` into a single timer; we would simply adjust duration and error messages depending on `conn.established` state.
* Alternatively, the heartbeat timeout could run at the same time as the established timeout rather than being kicked off once we know our heartbeat has got through to the other side.

