### PR TITLE
Avoid some deadlocks on full channel buffer

### DIFF
--- a/router/consts.go
+++ b/router/consts.go
@@ -12,7 +12,7 @@ const (
 	HttpPort           = Port + 1
 	DefaultPMTU        = 65535
 	MaxUDPPacketSize   = 65536
-	ChannelSize        = 16
+	ChannelSize        = 1024
 	UDPNonceSendAt     = 8192
 	FragTestSize       = 60001
 	PMTUDiscoverySize  = 60000


### PR DESCRIPTION
We have seen in #415 how deadlocks can occur when channel buffers fill up; raising the capacity from 16 to 1024 makes this less likely.

It is not a final fix for the problem, since outgoing TCP delays or other reasons can still cause a channel to back up.

This problem was discovered while researching #411.