### PR TITLE
Remove deadlock in sending protocol messages

### DIFF
--- a/router/connection.go
+++ b/router/connection.go
@@ -181,9 +181,11 @@ func (conn *LocalConnection) log(args ...interface{}) {
 	log.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s]:", conn.remote.Name)), args...)...)
 }
 
-// Send directly - not via the Actor queryLoop.
-// note that tcpSender is immutable and guaranteed to be set by the
-// time anybody can get hold of a ref to the Connection
+// Send directly, not via the Actor.  If it goes via the Actor we can
+// get a deadlock where LocalConnection is blocked talking to
+// LocalPeer and LocalPeer is blocked trying send a ProtocolMsg via
+// LocalConnection, and the channels are full in both directions so
+// nothing can proceed.
 func (conn *LocalConnection) SendProtocolMsg(m ProtocolMsg) {
 	if err := conn.sendProtocolMsg(m); err != nil {
 		conn.Shutdown(err)


### PR DESCRIPTION
As noted in #415, the Actor channels into LocalPeer and a Connection can get locked in a deadly embrace.

But, we don't need to use the Actor mechanism for outgoing ProtocolMsg sends; they don't need to be serialised with the state of the Connection itself, so by doing the send directly we avoid this problem.

This then opens up a related problem that the Shutdown() arising from an error when sending can get blocked on a full channel, so we move all Shutdown() operations to their own goroutines.

Closes #415.  Possibly related to #411.