### PR TITLE
weave-225: [dns] caching (1/3)

### DIFF
--- a/nameserver/cache.go
+++ b/nameserver/cache.go
@@ -1,0 +1,370 @@
+package nameserver
+
+import (
+	"container/heap"
+	"errors"
+	"github.com/miekg/dns"
+	. "github.com/zettio/weave/common"
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var (
+	errInvalidCapacity = errors.New("Invalid cache capacity")
+	errCouldNotResolve = errors.New("Could not resolve")
+	errTimeout         = errors.New("Timeout while waiting for resolution")
+	errNoLocalReplies  = errors.New("No local replies")
+)
+
+const (
+	defPendingTimeout int = 5  // timeout for a resolution
+)
+
+type entryStatus uint8
+
+const (
+	stPending  entryStatus = iota // someone is waiting for the resolution
+	stResolved entryStatus = iota // resolved
+)
+
+const (
+	CacheNoLocalReplies uint8 = 1 << iota // not found in local network (stored in the cache so we skip another local lookup or some time)
+)
+
+// shuffleAnswers reorders answers for very basic load balancing
+func shuffleAnswers(answers []dns.RR) []dns.RR {
+	n := len(answers)
+	if n > 1 {
+		rand.Seed(time.Now().UTC().UnixNano())
+
+		for i := 0; i < n; i++ {
+			r := i + rand.Intn(n-i)
+			answers[r], answers[i] = answers[i], answers[r]
+		}
+	}
+
+	return answers
+}
+
+// a cache entry
+type cacheEntry struct {
+	Status   entryStatus // status of the entry
+	Flags    uint8       // some extra flags
+	ReplyLen int
+
+	question dns.Question
+	protocol dnsProtocol
+	reply    dns.Msg
+
+	validUntil time.Time // obtained from the reply and stored here for convenience/speed
+	putTime    time.Time
+
+	waitChan chan struct{}
+
+	index int // for fast lookups in the heap
+}
+
+func newCacheEntry(question *dns.Question, reply *dns.Msg, status entryStatus, flags uint8, now time.Time) *cacheEntry {
+	e := &cacheEntry{
+		Status:   status,
+		Flags:    flags,
+		question: *question,
+		index:    -1,
+	}
+
+	if e.Status == stPending {
+		e.validUntil = now.Add(time.Duration(defPendingTimeout) * time.Second)
+		e.waitChan = make(chan struct{})
+	} else {
+		e.setReply(reply, flags, now)
+	}
+
+	return e
+}
+
+// Get a copy of the reply stored in the entry, but with some values adjusted like the TTL
+func (e *cacheEntry) getReply(request *dns.Msg, maxLen int, now time.Time) (*dns.Msg, error) {
+	if e.Status != stResolved {
+		return nil, nil
+	}
+
+	// if the reply has expired or is invalid, force the caller to start a new resolution
+	if e.hasExpired(now) {
+		return nil, nil
+	}
+
+	if e.Flags&CacheNoLocalReplies != 0 {
+		return nil, errNoLocalReplies
+	}
+
+	if e.ReplyLen >= maxLen {
+		Debug.Printf("[cache] returning truncated reponse: %d > %d", e.ReplyLen, maxLen)
+		return makeTruncatedReply(request), nil
+	}
+
+	// create a copy of the reply, with values for this particular query
+	reply := e.reply
+	reply.SetReply(request)
+	reply.Rcode = e.reply.Rcode
+	reply.Authoritative = true
+
+	// adjust the TTLs
+	passedSecs := uint32(now.Sub(e.putTime).Seconds())
+	for _, rr := range reply.Answer {
+		ttl := rr.Header().Ttl
+		if passedSecs < ttl {
+			rr.Header().Ttl = ttl - passedSecs
+		} else {
+			rr.Header().Ttl = 0
+		}
+	}
+
+	// shuffle the values, etc...
+	reply.Answer = shuffleAnswers(reply.Answer)
+
+	return &reply, nil
+}
+
+func (e cacheEntry) hasExpired(now time.Time) bool {
+	return e.validUntil.Before(now) || e.validUntil == now
+}
+
+// set the reply for the entry
+// returns True if the entry has changed the validUntil time
+func (e *cacheEntry) setReply(reply *dns.Msg, flags uint8, now time.Time) bool {
+	shouldNotify := (e.Status == stPending)
+
+	var prevValidUntil time.Time
+	if e.Status == stResolved {
+		prevValidUntil = e.validUntil
+	}
+
+	e.Status = stResolved
+	e.Flags = flags
+	e.putTime = now
+
+	if e.Flags&CacheNoLocalReplies != 0 {
+		// use a fixed timeout for negative local resolutions
+		e.validUntil = now.Add(time.Second * time.Duration(negLocalTTL))
+	} else {
+		// calculate the validUntil from the reply TTL
+		var minTtl uint32 = math.MaxUint32
+		for _, rr := range reply.Answer {
+			ttl := rr.Header().Ttl
+			if ttl < minTtl {
+				minTtl = ttl // TODO: improve the minTTL calculation (maybe we should skip some RRs)
+			}
+		}
+		e.validUntil = now.Add(time.Second * time.Duration(minTtl))
+	}
+
+	if reply != nil {
+		e.reply = *reply
+		e.ReplyLen = reply.Len()
+	}
+
+	if shouldNotify {
+		close(e.waitChan) // notify all the waiters by closing the channel
+	}
+
+	return (prevValidUntil != e.validUntil)
+}
+
+// wait until a valid reply is set in the cache
+func (e *cacheEntry) waitReply(request *dns.Msg, timeout time.Duration, maxLen int, now time.Time) (*dns.Msg, error) {
+	if e.Status == stResolved {
+		return e.getReply(request, maxLen, now)
+	}
+
+	if timeout > 0 {
+		select {
+		case <-e.waitChan:
+			return e.getReply(request, maxLen, now)
+		case <-time.After(time.Second * timeout):
+			return nil, errTimeout
+		}
+	}
+
+	return nil, errCouldNotResolve
+}
+
+func (e *cacheEntry) close() {
+	if e.Status == stPending {
+		close(e.waitChan)
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////////////
+
+// An entriesPtrHeap is a min-heap of cache entries.
+type entriesPtrsHeap []*cacheEntry
+
+func (h entriesPtrsHeap) Len() int           { return len(h) }
+func (h entriesPtrsHeap) Less(i, j int) bool { return h[i].validUntil.Before(h[j].validUntil) }
+func (h entriesPtrsHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+
+func (h *entriesPtrsHeap) Push(x interface{}) {
+	// Push and Pop use pointer receivers because they modify the slice's length,
+	// not just its contents.
+	n := len(*h)
+	entry := x.(*cacheEntry)
+	entry.index = n
+	*h = append(*h, entry)
+}
+
+func (h *entriesPtrsHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	item.index = -1 // for safety
+	*h = old[0 : n-1]
+	return item
+}
+
+//////////////////////////////////////////////////////////////////////////////////////
+
+type cacheKey dns.Question
+type entries map[cacheKey]*cacheEntry
+
+// Cache is a thread-safe fixed capacity LRU cache.
+type Cache struct {
+	Capacity int
+
+	entries  entries
+	entriesH entriesPtrsHeap // len(entriesH) <= len(entries), as pending entries can be in entries but not in entriesH
+	lock     sync.RWMutex
+}
+
+// NewCache creates a cache of the given capacity
+func NewCache(capacity int) (*Cache, error) {
+	if capacity <= 0 {
+		return nil, errInvalidCapacity
+	}
+	c := &Cache{
+		Capacity: capacity,
+		entries:  make(entries, capacity),
+	}
+
+	heap.Init(&c.entriesH)
+	return c, nil
+}
+
+// Clear removes all the entries in the cache
+func (c *Cache) Clear() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.entries = make(entries, c.Capacity)
+	heap.Init(&c.entriesH)
+}
+
+// Purge removes the old elements in the cache
+func (c *Cache) Purge(now time.Time) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for i, entry := range c.entriesH {
+		if entry.hasExpired(now) {
+			heap.Remove(&c.entriesH, i)
+			delete(c.entries, cacheKey(entry.question))
+		} else {
+			return // all remaining entries must be still valid...
+		}
+	}
+}
+
+// Add adds a reply to the cache.
+func (c *Cache) Put(request *dns.Msg, reply *dns.Msg, flags uint8, now time.Time) int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	question := request.Question[0]
+	key := cacheKey(question)
+	ent, found := c.entries[key]
+	if found {
+		Debug.Printf("[cache msgid %d] replacing response in cache", request.MsgHdr.Id)
+		updated := ent.setReply(reply, flags, now)
+		if updated {
+			heap.Fix(&c.entriesH, ent.index)
+		}
+	} else {
+		// If we will add a new item and the capacity has been exceeded, make some room...
+		if len(c.entriesH) >= c.Capacity {
+			lowestEntry := heap.Pop(&c.entriesH).(*cacheEntry)
+			lowestEntry.close()
+			delete(c.entries, cacheKey(lowestEntry.question))
+		}
+		ent = newCacheEntry(&question, reply, stResolved, flags, now)
+		heap.Push(&c.entriesH, ent)
+		c.entries[key] = ent
+	}
+	return ent.ReplyLen
+}
+
+// Look up for a question's reply from the cache.
+// If no reply is stored in the cache, it returns a `nil` reply and no error. The caller can then `Wait()`
+// for another goroutine `Put`ing a reply in the cache.
+func (c *Cache) Get(request *dns.Msg, maxLen int, now time.Time) (reply *dns.Msg, err error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	question := request.Question[0]
+	key := cacheKey(question)
+	if ent, found := c.entries[key]; found {
+		reply, err = ent.getReply(request, maxLen, now)
+		if ent.hasExpired(now) {
+			Debug.Printf("[cache msgid %d] expired: removing", request.MsgHdr.Id)
+			if ent.index > 0 {
+				heap.Remove(&c.entriesH, ent.index)
+			}
+			delete(c.entries, key)
+			reply = nil
+		}
+	} else {
+		// we are the first asking for this name: create an entry with no reply... the caller must wait
+		Debug.Printf("[cache msgid %d] addind in pending state", request.MsgHdr.Id)
+		c.entries[key] = newCacheEntry(&question, nil, stPending, 0, now)
+	}
+	return
+}
+
+// Wait for a reply for a question in the cache
+// Notice that the caller could Get() and then Wait() for a question, but the corresponding cache
+// entry could have been removed in between. In that case, the caller should retry the query (and
+// the user should increase the cache size!)
+func (c *Cache) Wait(request *dns.Msg, timeout time.Duration, maxLen int, now time.Time) (reply *dns.Msg, err error) {
+	// do not try to lock the cache: otherwise, no one else could `Put()` the reply
+	question := request.Question[0]
+	if entry, found := c.entries[cacheKey(question)]; found {
+		reply, err = entry.waitReply(request, timeout, maxLen, now)
+	}
+	return
+}
+
+// Remove removes the provided question from the cache.
+func (c *Cache) Remove(question *dns.Question) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	key := cacheKey(*question)
+	if entry, found := c.entries[key]; found {
+		if entry.index > 0 {
+			heap.Remove(&c.entriesH, entry.index)
+		}
+		delete(c.entries, key)
+	}
+}
+
+// Len returns the number of entries in the cache.
+func (c *Cache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return len(c.entries)
+}

--- a/nameserver/cache_test.go
+++ b/nameserver/cache_test.go
@@ -1,0 +1,258 @@
+package nameserver
+
+import (
+	"fmt"
+	"github.com/miekg/dns"
+	. "github.com/zettio/weave/common"
+	wt "github.com/zettio/weave/testing"
+	"net"
+	"testing"
+	"time"
+)
+
+// Check that the cache keeps its intended capacity constant
+func TestCacheLength(t *testing.T) {
+	InitDefaultLogging(true)
+
+	const cacheLen = 128
+
+	l, err := NewCache(cacheLen)
+	wt.AssertNoErr(t, err)
+
+	insTime := time.Now()
+
+	t.Logf("Inserting 256 questions in the cache at '%s', with TTL from 0 to 255", insTime)
+	for i := 0; i < cacheLen*2; i++ {
+		questionMsg := new(dns.Msg)
+		questionMsg.SetQuestion(fmt.Sprintf("name%d", i), dns.TypeA)
+		questionMsg.RecursionDesired = true
+
+		question := &questionMsg.Question[0]
+
+		ip := net.ParseIP(fmt.Sprintf("10.0.1.%d", i))
+		ips := []net.IP{ip}
+		reply := makeAddressReply(questionMsg, question, ips)
+		reply.Answer[0].Header().Ttl = uint32(i)
+
+		l.Put(questionMsg, reply, 0, insTime)
+	}
+
+	wt.AssertEqualInt(t, l.Len(), cacheLen, "cache length")
+
+	minExpectedTime := insTime.Add(time.Duration(cacheLen) * time.Second)
+	t.Logf("Checking all remaining entries expire after insert_time + %d secs='%s'", cacheLen, minExpectedTime)
+	for _, entry := range l.entries {
+		if entry.validUntil.Before(minExpectedTime) {
+			t.Fatalf("Entry valid until %s", entry.validUntil)
+		}
+	}
+}
+
+// Check that the cache entries are ok
+func TestCacheEntries(t *testing.T) {
+	InitDefaultLogging(true)
+
+	Info.Println("Checking cache consistency")
+
+	const cacheLen = 128
+
+	l, err := NewCache(cacheLen)
+	wt.AssertNoErr(t, err)
+
+	questionMsg := new(dns.Msg)
+	questionMsg.SetQuestion("some.name", dns.TypeA)
+	questionMsg.RecursionDesired = true
+
+	question := &questionMsg.Question[0]
+
+	t.Logf("Trying to get a name")
+	resp, err := l.Get(questionMsg, minUdpSize, time.Now())
+	wt.AssertNoErr(t, err)
+	if resp != nil {
+		t.Logf("Got '%s'", resp)
+		t.Fatalf("ERROR: Did not expect a reponse from Get() yet")
+	}
+	t.Logf("Trying to get it again")
+	resp, err = l.Get(questionMsg, minUdpSize, time.Now())
+	wt.AssertNoErr(t, err)
+	if resp != nil {
+		t.Logf("Got '%s'", resp)
+		t.Fatalf("ERROR: Did not expect a reponse from Get() yet")
+	}
+
+	t.Logf("Inserting the reply")
+	reply1 := makeAddressReply(questionMsg, question, []net.IP{net.ParseIP("10.0.1.1")})
+	l.Put(questionMsg, reply1, 0, time.Now())
+
+	timeGet1 := time.Now()
+	t.Logf("Checking we can Get() the reply now")
+	resp, err = l.Get(questionMsg, minUdpSize, timeGet1)
+	wt.AssertNoErr(t, err)
+	wt.AssertTrue(t, resp != nil, "reponse from Get()")
+	t.Logf("Received '%s'", resp.Answer[0])
+	wt.AssertType(t, resp.Answer[0], (*dns.A)(nil), "DNS record")
+	ttlGet1 := resp.Answer[0].Header().Ttl
+
+	t.Logf("Checking a Wait() with timeout=0 gets the same result")
+	resp, err = l.Wait(questionMsg, time.Duration(0)*time.Second, minUdpSize, time.Now())
+	wt.AssertNoErr(t, err)
+	wt.AssertTrue(t, resp != nil, "reponse from a Wait(timeout=0)")
+	t.Logf("Received '%s'", resp.Answer[0])
+	wt.AssertType(t, resp.Answer[0], (*dns.A)(nil), "DNS record")
+
+	timeGet2 := timeGet1.Add(time.Duration(1) * time.Second)
+	t.Logf("Checking that a second Get(), after 1 second, gets the same result, but with reduced TTL")
+	resp, err = l.Get(questionMsg, minUdpSize, timeGet2)
+	wt.AssertNoErr(t, err)
+	wt.AssertTrue(t, resp != nil, "reponse from a second Get()")
+	t.Logf("Received '%s'", resp.Answer[0])
+	wt.AssertType(t, resp.Answer[0], (*dns.A)(nil), "DNS record")
+	ttlGet2 := resp.Answer[0].Header().Ttl
+	wt.AssertEqualInt(t, int(ttlGet1 - ttlGet2), 1, "TTL difference")
+
+	timeGet3 := timeGet1.Add(time.Duration(localTTL) * time.Second)
+	t.Logf("Checking that a third Get(), after %d second, gets no result", localTTL)
+	resp, err = l.Get(questionMsg, minUdpSize, timeGet3)
+	wt.AssertNoErr(t, err)
+	if resp != nil {
+		t.Logf("Got '%s'", resp)
+		t.Fatalf("ERROR: Did NOT expect a reponse from the second Get()")
+	}
+
+	t.Logf("Checking that an Remove() results in Get() returning nothing")
+	replyTemp := makeAddressReply(questionMsg, question, []net.IP{net.ParseIP("10.0.9.9")})
+	l.Put(questionMsg, replyTemp, 0, time.Now())
+	lenBefore := l.Len()
+	l.Remove(question)
+	wt.AssertEqualInt(t, l.Len(), lenBefore - 1, "cache length")
+	l.Remove(question) // do it again: should have no effect...
+	wt.AssertEqualInt(t, l.Len(), lenBefore - 1, "cache length")
+
+	resp, err = l.Get(questionMsg, minUdpSize, timeGet1)
+	wt.AssertNoErr(t, err)
+	wt.AssertTrue(t, resp == nil, "reponse from the Get() after a Remove()")
+
+	t.Logf("Inserting a two replies for the same query")
+	timePut2 := time.Now()
+	reply2 := makeAddressReply(questionMsg, question, []net.IP{net.ParseIP("10.0.1.2")})
+	l.Put(questionMsg, reply2, 0, timePut2)
+	timePut3 := timePut2.Add(time.Duration(1) * time.Second)
+	reply3 := makeAddressReply(questionMsg, question, []net.IP{net.ParseIP("10.0.1.3")})
+	l.Put(questionMsg, reply3, 0, timePut3)
+
+	t.Logf("Checking we get the last one...")
+	resp, err = l.Get(questionMsg, minUdpSize, timePut3)
+	wt.AssertNoErr(t, err)
+	wt.AssertTrue(t, resp != nil, "reponse from the Get()")
+	t.Logf("Received '%s'", resp.Answer[0])
+	wt.AssertType(t, resp.Answer[0], (*dns.A)(nil), "DNS record")
+	wt.AssertEqualString(t, resp.Answer[0].(*dns.A).A.String(), "10.0.1.3", "IP address")
+	wt.AssertEqualInt(t, int(resp.Answer[0].Header().Ttl), int(localTTL), "TTL")
+
+	resp, err = l.Get(questionMsg, minUdpSize, timePut3.Add(time.Duration(localTTL - 1) * time.Second))
+	wt.AssertNoErr(t, err)
+	wt.AssertTrue(t, resp != nil, "reponse from the Get()")
+	t.Logf("Received '%s'", resp.Answer[0])
+	wt.AssertType(t, resp.Answer[0], (*dns.A)(nil), "DNS record")
+	wt.AssertEqualString(t, resp.Answer[0].(*dns.A).A.String(), "10.0.1.3", "IP address")
+	wt.AssertEqualInt(t, int(resp.Answer[0].Header().Ttl), 1, "TTL")
+
+	t.Logf("Checking we get empty replies when they are expired...")
+	lenBefore = l.Len()
+	resp, err = l.Get(questionMsg, minUdpSize, timePut3.Add(time.Duration(localTTL) * time.Second))
+	wt.AssertNoErr(t, err)
+	if resp != nil {
+		t.Logf("Received '%s'", resp.Answer[0])
+		t.Fatalf("ERROR: Did NOT expect a reponse from the Get()")
+	}
+	wt.AssertEqualInt(t, l.Len(), lenBefore - 1, "cache length (after getting an expired entry)")
+
+	questionMsg2 := new(dns.Msg)
+	questionMsg2.SetQuestion("some.other.name", dns.TypeA)
+	questionMsg2.RecursionDesired = true
+	question2 := &questionMsg2.Question[0]
+
+	t.Logf("Trying to Get() a name")
+	resp, err = l.Get(questionMsg2, minUdpSize, time.Now())
+	wt.AssertNoErr(t, err)
+	wt.AssertNil(t, resp, "reponse from Get() yet")
+
+	t.Logf("Checking that an Remove() between Get() and Put() does not break things")
+	replyTemp2 := makeAddressReply(questionMsg2, question2, []net.IP{net.ParseIP("10.0.9.9")})
+	l.Remove(question2)
+	l.Put(questionMsg2, replyTemp2, 0, time.Now())
+	resp, err = l.Get(questionMsg2, minUdpSize, time.Now())
+	wt.AssertNoErr(t, err)
+	wt.AssertNotNil(t, resp, "reponse from Get()")
+	resp, err = l.Wait(questionMsg2, time.Duration(0)*time.Second, minUdpSize, time.Now())
+	wt.AssertNoErr(t, err)
+	wt.AssertNotNil(t, resp, "reponse from Get()")
+
+	questionMsg3 := new(dns.Msg)
+	questionMsg3.SetQuestion("some.other.name", dns.TypeA)
+	questionMsg3.RecursionDesired = true
+	question3 := &questionMsg3.Question[0]
+
+	t.Logf("Checking that a entry with CacheNoLocalReplies return an error")
+	timePut3 = time.Now()
+	l.Put(questionMsg3, nil, CacheNoLocalReplies, timePut3)
+	resp, err = l.Get(questionMsg3, minUdpSize, timePut3)
+	wt.AssertNil(t, resp, "Get() response with CacheNoLocalReplies")
+	wt.AssertNotNil(t, err, "Get() error with CacheNoLocalReplies")
+
+	timeExpiredGet3 := timePut3.Add(time.Second * time.Duration(negLocalTTL + 1))
+	t.Logf("Checking that we get an expired response after %f seconds", timeExpiredGet3.Sub(timePut3).Seconds())
+	resp, err = l.Get(questionMsg3, minUdpSize, timeExpiredGet3)
+	wt.AssertNil(t, resp, "expired Get() response with CacheNoLocalReplies")
+	wt.AssertNil(t, err, "expired Get() error with CacheNoLocalReplies")
+
+	l.Remove(question3)
+	t.Logf("Checking that Put&Get with CacheNoLocalReplies with a Remove in the middle returns nothing")
+	l.Put(questionMsg3, nil, CacheNoLocalReplies, time.Now())
+	l.Remove(question3)
+	resp, err = l.Get(questionMsg3, minUdpSize, time.Now())
+	wt.AssertNil(t, resp, "Get() reponse with CacheNoLocalReplies")
+	wt.AssertNil(t, err, "Get() error with CacheNoLocalReplies")
+}
+
+// Check that waiters are unblocked when the name they are waiting for is inserted
+func TestCacheBlockingOps(t *testing.T) {
+	InitDefaultLogging(true)
+
+	const cacheLen = 256
+
+	l, err := NewCache(cacheLen)
+	wt.AssertNoErr(t, err)
+
+	requests := []*dns.Msg{}
+
+	t.Logf("Starting 256 queries that will block...")
+	for i := 0; i < cacheLen; i++ {
+		questionName := fmt.Sprintf("name%d", i)
+		questionMsg := new(dns.Msg)
+		questionMsg.SetQuestion(questionName, dns.TypeA)
+		questionMsg.RecursionDesired = true
+
+		requests = append(requests, questionMsg)
+
+		go func(request *dns.Msg) {
+			t.Logf("Querying about %s...", request.Question[0].Name)
+			_, err := l.Get(request, minUdpSize, time.Now())
+			wt.AssertNoErr(t, err)
+			t.Logf("Waiting for %s...", request.Question[0].Name)
+			r, err := l.Wait(request, 1*time.Second, minUdpSize, time.Now())
+			t.Logf("Obtained response for %s:\n%s", request.Question[0].Name, r)
+			wt.AssertNoErr(t, err)
+		}(questionMsg)
+	}
+
+	// insert the IPs for those names
+	for i, requestMsg := range requests {
+		ip := net.ParseIP(fmt.Sprintf("10.0.1.%d", i))
+		ips := []net.IP{ip}
+		reply := makeAddressReply(requestMsg, &requestMsg.Question[0], ips)
+
+		t.Logf("Inserting response for %s...", requestMsg.Question[0].Name)
+		l.Put(requestMsg, reply, 0, time.Now())
+	}
+}

--- a/testing/util.go
+++ b/testing/util.go
@@ -9,13 +9,28 @@ import (
 
 func AssertTrue(t *testing.T, cond bool, desc string) {
 	if !cond {
-		Fatalf(t, "Expected %s to be true", desc)
+		Fatalf(t, "Expected %s", desc)
 	}
 }
 
 func AssertFalse(t *testing.T, cond bool, desc string) {
 	if cond {
-		Fatalf(t, "Expected %s to be false", desc)
+		Fatalf(t, "Unexpected %s", desc)
+	}
+}
+
+func AssertNil(t *testing.T, p interface{}, desc string) {
+	val := reflect.ValueOf(p)
+	if val.IsValid() && !val.IsNil() {
+		Fatalf(t, "Expected nil pointer for %s but got a \"%s\": \"%s\"",
+			desc, reflect.TypeOf(p), val.Interface())
+	}
+}
+
+func AssertNotNil(t *testing.T, p interface{}, desc string) {
+	val := reflect.ValueOf(p)
+	if !val.IsValid() || val.IsNil() {
+		Fatalf(t, "Unexpected nil pointer for %s", desc)
 	}
 }
 

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -10,6 +10,9 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
 )
 
 var version = "(unreleased version)"
@@ -24,6 +27,9 @@ func main() {
 		dnsPort     int
 		httpPort    int
 		wait        int
+		timeout     int
+		udpbuf      int
+		cacheLen    int
 		watch       bool
 		debug       bool
 		err         error
@@ -31,12 +37,15 @@ func main() {
 
 	flag.BoolVar(&justVersion, "version", false, "print version and exit")
 	flag.StringVar(&ifaceName, "iface", "", "name of interface to use for multicast")
-	flag.StringVar(&apiPath, "api", "unix:///var/run/docker.sock", "Path to Docker API socket")
-	flag.StringVar(&localDomain, "localDomain", weavedns.DEFAULT_LOCAL_DOMAIN, "local domain (e.g., 'weave.local.')")
+	flag.StringVar(&apiPath, "api", "unix:///var/run/docker.sock", "path to Docker API socket")
+	flag.StringVar(&localDomain, "localDomain", weavedns.DEFAULT_LOCAL_DOMAIN, "local domain (ie, 'weave.local.')")
 	flag.IntVar(&wait, "wait", 0, "number of seconds to wait for interface to be created and come up")
-	flag.IntVar(&dnsPort, "dnsport", 53, "port to listen to DNS requests")
+	flag.IntVar(&dnsPort, "dnsport", weavedns.DEFAULT_SERVER_PORT, "port to listen to DNS requests")
 	flag.IntVar(&httpPort, "httpport", 6785, "port to listen to HTTP requests")
-	flag.StringVar(&fallback, "fallback", "", "fallback server and port (ie, '8.8.8.8:53')")
+	flag.StringVar(&fallback, "fallback", "", "force a fallback (ie, '8.8.8.8:53') instead of /etc/resolv.conf values")
+	flag.IntVar(&timeout, "timeout", weavedns.DEFAULT_TIMEOUT, "timeout for resolutions")
+	flag.IntVar(&udpbuf, "udpbuf", weavedns.DEFAULT_UDP_BUFLEN, "UDP buffer length")
+	flag.IntVar(&cacheLen, "cache", weavedns.DEFAULT_CACHE_LEN, "cache length")
 	flag.BoolVar(&watch, "watch", true, "watch the docker socket for container events")
 	flag.BoolVar(&debug, "debug", false, "output debugging info to stderr")
 	flag.Parse()
@@ -70,8 +79,11 @@ func main() {
 	}
 
 	srvConfig := weavedns.DNSServerConfig{
-		Port:        dnsPort,
-		LocalDomain: localDomain,
+		Port:                dnsPort,
+		CacheLen:            cacheLen,
+		LocalDomain:         localDomain,
+		Timeout:             timeout,
+		UdpBufLen:           udpbuf,
 	}
 
 	if len(fallback) > 0 {
@@ -82,14 +94,36 @@ func main() {
 		srvConfig.UpstreamCfg = &dns.ClientConfig{Servers: []string{fallbackHost}, Port: fallbackPort}
 		Debug.Printf("DNS fallback at %s:%s", fallbackHost, fallbackPort)
 	}
-
+	
 	srv, err := weavedns.NewDNSServer(srvConfig, zone, iface)
 	if err != nil {
 		Error.Fatal("Failed to initialize the WeaveDNS server", err)
 	}
+
+	Debug.Printf("Starting the signals handler")
+	go handleSignals(srv)
+
 	go weavedns.ListenHttp(version, srv, localDomain, zone, httpPort)
 	err = srv.Start()
 	if err != nil {
 		Error.Fatal("Failed to start the WeaveDNS server", err)
+	}
+}
+
+func handleSignals(s *weavedns.DNSServer) {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGQUIT)
+	buf := make([]byte, 1<<20)
+	for {
+		sig := <-sigs
+		switch sig {
+		case syscall.SIGINT:
+			Info.Printf("=== received SIGINT ===\n*** exiting\n")
+			s.Stop()
+			os.Exit(0)
+		case syscall.SIGQUIT:
+			stacklen := runtime.Stack(buf, true)
+			Info.Printf("=== received SIGQUIT ===\n*** goroutine dump...\n%s\n*** end\n", buf[:stacklen])
+		}
 	}
 }


### PR DESCRIPTION
#225 : this pull request implements a caching mechanism in the DNS server. The cache is used for saving positive and negative replies obtained by the local discovery system as well as by the recursive resolver.

Replies found in the cache are modified before being returned to clients by adjusting the remaining TTL and  shuffling answers (implementing a basic load balancing mechanism as a side effect, a first step for #226).
