### PR TITLE
Avoid many pointless connection attempts

### DIFF
--- a/router/connection.go
+++ b/router/connection.go
@@ -16,6 +16,7 @@ type Connection interface {
 	BreakTie(Connection) ConnectionTieBreak
 	RemoteTCPAddr() string
 	Established() bool
+	Outbound() bool
 	Shutdown(error)
 	Log(args ...interface{})
 }
@@ -33,6 +34,7 @@ type RemoteConnection struct {
 	remote        *Peer
 	remoteTCPAddr string
 	established   bool
+	outbound      bool
 }
 
 type LocalConnection struct {
@@ -66,12 +68,13 @@ type ConnectionInteraction struct {
 	payload interface{}
 }
 
-func NewRemoteConnection(from, to *Peer, tcpAddr string, established bool) *RemoteConnection {
+func NewRemoteConnection(from, to *Peer, tcpAddr string, established bool, outbound bool) *RemoteConnection {
 	return &RemoteConnection{
 		local:         from,
 		remote:        to,
 		remoteTCPAddr: tcpAddr,
-		established:   established}
+		established:   established,
+		outbound:      outbound}
 }
 
 func (conn *RemoteConnection) Local() *Peer {
@@ -92,6 +95,10 @@ func (conn *RemoteConnection) RemoteTCPAddr() string {
 
 func (conn *RemoteConnection) Established() bool {
 	return conn.established
+}
+
+func (conn *RemoteConnection) Outbound() bool {
+	return conn.outbound
 }
 
 func (conn *RemoteConnection) Shutdown(error) {

--- a/router/connection.go
+++ b/router/connection.go
@@ -13,10 +13,10 @@ import (
 type Connection interface {
 	Local() *Peer
 	Remote() *Peer
-	BreakTie(Connection) ConnectionTieBreak
 	RemoteTCPAddr() string
-	Established() bool
 	Outbound() bool
+	Established() bool
+	BreakTie(Connection) ConnectionTieBreak
 	Shutdown(error)
 	Log(args ...interface{})
 }
@@ -33,8 +33,8 @@ type RemoteConnection struct {
 	local         *Peer
 	remote        *Peer
 	remoteTCPAddr string
-	established   bool
 	outbound      bool
+	established   bool
 }
 
 type LocalConnection struct {
@@ -68,41 +68,23 @@ type ConnectionInteraction struct {
 	payload interface{}
 }
 
-func NewRemoteConnection(from, to *Peer, tcpAddr string, established bool, outbound bool) *RemoteConnection {
+func NewRemoteConnection(from, to *Peer, tcpAddr string, outbound bool, established bool) *RemoteConnection {
 	return &RemoteConnection{
 		local:         from,
 		remote:        to,
 		remoteTCPAddr: tcpAddr,
+		outbound:      outbound,
 		established:   established,
-		outbound:      outbound}
+	}
 }
 
-func (conn *RemoteConnection) Local() *Peer {
-	return conn.local
-}
-
-func (conn *RemoteConnection) Remote() *Peer {
-	return conn.remote
-}
-
-func (conn *RemoteConnection) BreakTie(Connection) ConnectionTieBreak {
-	return TieBreakTied
-}
-
-func (conn *RemoteConnection) RemoteTCPAddr() string {
-	return conn.remoteTCPAddr
-}
-
-func (conn *RemoteConnection) Established() bool {
-	return conn.established
-}
-
-func (conn *RemoteConnection) Outbound() bool {
-	return conn.outbound
-}
-
-func (conn *RemoteConnection) Shutdown(error) {
-}
+func (conn *RemoteConnection) Local() *Peer                           { return conn.local }
+func (conn *RemoteConnection) Remote() *Peer                          { return conn.remote }
+func (conn *RemoteConnection) RemoteTCPAddr() string                  { return conn.remoteTCPAddr }
+func (conn *RemoteConnection) Outbound() bool                         { return conn.outbound }
+func (conn *RemoteConnection) Established() bool                      { return conn.established }
+func (conn *RemoteConnection) BreakTie(Connection) ConnectionTieBreak { return TieBreakTied }
+func (conn *RemoteConnection) Shutdown(error)                         {}
 
 func (conn *RemoteConnection) Log(args ...interface{}) {
 	log.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s]:", conn.remote.Name)), args...)...)

--- a/router/connection_maker.go
+++ b/router/connection_maker.go
@@ -140,12 +140,14 @@ func (cm *ConnectionMaker) checkStateAndAttemptConnections() time.Duration {
 	// aren't
 	cm.peers.ForEach(func(name PeerName, peer *Peer) {
 		peer.ForEachConnection(func(otherPeer PeerName, conn Connection) {
-			if otherPeer == cm.ourself.Name || ourConnectedPeers[otherPeer] || !conn.Outbound() {
+			if otherPeer == cm.ourself.Name || ourConnectedPeers[otherPeer] {
 				return
 			}
 			address := conn.RemoteTCPAddr()
-			// try both portnumber of connection and standard port
-			addTarget(address)
+			// try both portnumber of connection and standard port.  Don't use remote side of inbound connection.
+			if conn.Outbound() {
+				addTarget(address)
+			}
 			if host, _, err := net.SplitHostPort(address); err == nil {
 				addTarget(NormalisePeerAddr(host))
 			}

--- a/router/connection_maker.go
+++ b/router/connection_maker.go
@@ -140,7 +140,7 @@ func (cm *ConnectionMaker) checkStateAndAttemptConnections() time.Duration {
 	// aren't
 	cm.peers.ForEach(func(name PeerName, peer *Peer) {
 		peer.ForEachConnection(func(otherPeer PeerName, conn Connection) {
-			if otherPeer == cm.ourself.Name || ourConnectedPeers[otherPeer] {
+			if otherPeer == cm.ourself.Name || ourConnectedPeers[otherPeer] || !conn.Outbound() {
 				return
 			}
 			address := conn.RemoteTCPAddr()

--- a/router/gossip_test.go
+++ b/router/gossip_test.go
@@ -41,7 +41,7 @@ func (router *Router) AddTestChannelConnection(r *Router) {
 	r.Peers.FetchWithDefault(fromPeer)    // Has side-effect of incrementing refcount
 	router.Peers.FetchWithDefault(toPeer) //
 
-	conn := &mockChannelConnection{RemoteConnection{router.Ourself.Peer, toPeer, "", false}, r}
+	conn := &mockChannelConnection{RemoteConnection{router.Ourself.Peer, toPeer, "", false, true}, r}
 	router.Ourself.handleAddConnection(conn)
 	router.Ourself.handleConnectionEstablished(conn)
 }

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -111,7 +111,7 @@ func (peer *LocalPeer) CreateConnection(peerAddr string, acceptNewPeer bool) err
 	if err != nil {
 		return err
 	}
-	connRemote := NewRemoteConnection(peer.Peer, nil, tcpConn.RemoteAddr().String(), false, true)
+	connRemote := NewRemoteConnection(peer.Peer, nil, tcpConn.RemoteAddr().String(), true, false)
 	connLocal := NewLocalConnection(connRemote, tcpConn, udpAddr, peer.Router)
 	connLocal.Start(acceptNewPeer)
 	return nil

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -111,7 +111,7 @@ func (peer *LocalPeer) CreateConnection(peerAddr string, acceptNewPeer bool) err
 	if err != nil {
 		return err
 	}
-	connRemote := NewRemoteConnection(peer.Peer, nil, tcpConn.RemoteAddr().String(), false)
+	connRemote := NewRemoteConnection(peer.Peer, nil, tcpConn.RemoteAddr().String(), false, true)
 	connLocal := NewLocalConnection(connRemote, tcpConn, udpAddr, peer.Router)
 	connLocal.Start(acceptNewPeer)
 	return nil

--- a/router/mocks_test.go
+++ b/router/mocks_test.go
@@ -27,7 +27,7 @@ func (peers *Peers) AddTestRemoteConnection(p1, p2 *Peer) {
 	toName := p2.Name
 	toPeer := NewPeer(toName, "", p2.UID, 0)
 	toPeer = peers.FetchWithDefault(toPeer)
-	peers.ourself.addConnection(&RemoteConnection{fromPeer, toPeer, "", false})
+	peers.ourself.addConnection(&RemoteConnection{fromPeer, toPeer, "", false, false})
 }
 
 func (peers *Peers) DeleteTestConnection(p *Peer) {
@@ -44,7 +44,7 @@ func (peers *Peers) DeleteTestConnection(p *Peer) {
 // from what is created by the real code.
 func newMockConnection(from, to *Peer) Connection {
 	type mockConnection struct{ RemoteConnection }
-	return &mockConnection{RemoteConnection{from, to, "", false}}
+	return &mockConnection{RemoteConnection{from, to, "", false, false}}
 }
 
 func checkEqualConns(t *testing.T, ourName PeerName, got, wanted map[PeerName]Connection) {

--- a/router/protocol.go
+++ b/router/protocol.go
@@ -2,7 +2,7 @@ package router
 
 const (
 	Protocol        = "weave"
-	ProtocolVersion = 13
+	ProtocolVersion = 14
 )
 
 type ProtocolTag byte

--- a/router/router.go
+++ b/router/router.go
@@ -192,7 +192,7 @@ func (router *Router) acceptTCP(tcpConn *net.TCPConn) {
 	// start.
 	remoteAddrStr := tcpConn.RemoteAddr().String()
 	log.Printf("->[%s] connection accepted\n", remoteAddrStr)
-	connRemote := NewRemoteConnection(router.Ourself.Peer, nil, remoteAddrStr, false)
+	connRemote := NewRemoteConnection(router.Ourself.Peer, nil, remoteAddrStr, false, false)
 	connLocal := NewLocalConnection(connRemote, tcpConn, nil, router)
 	connLocal.Start(true)
 }


### PR DESCRIPTION
Add an 'outbound' field on each connection, and only attempt new connections to the remote side of outbound connections.
This fixes #448, which is particularly important as you raise the connection limit per #426.

NOTE: This changes the wire protocol, hence the protocol version number is incremented.