### PR TITLE
send all gossip to new peers only

### DIFF
--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -209,9 +209,14 @@ func (peer *LocalPeer) handleAddConnection(conn Connection) {
 		conn.Shutdown(err)
 		return
 	}
+	_, isConnectedPeer := peer.Router.Routes.Unicast(toName)
 	peer.addConnection(conn)
-	conn.Log("connection added")
-	peer.Router.SendAllGossipDown(conn)
+	if isConnectedPeer {
+		conn.Log("connection added")
+	} else {
+		conn.Log("connection added (new peer)")
+		peer.Router.SendAllGossipDown(conn)
+	}
 	peer.broadcastPeerUpdate(conn.Remote())
 }
 


### PR DESCRIPTION
Weave sends all gossip down new connections. We do this so that new
peers learn about all gossip'ed information quickly, thus enabling
them to process subsequent incremental updates. In particular, for
topology gossip it ensures that the remote peer learns about all other
peers. This ensures that the incremental update, which is sent as a
result of the new connection getting established and which may
reference a number of other peers, can be processed.

So the intent really is to send all gossip to new peers. But what we
actually do is send it down every new connection. Not every new
connection is from a new peer. In fact most connections aren't. Hence
the current approach is wasteful.

To fix this we need a conservative detection of new peers, i.e. it is
preferable to have false positives. This contrasts with existing logic
in the handshake code. The criteria we use is whether our peer has a
unicast route to the other peer. That is only the case when there is a
continuos chain of symmetric, established connections. The
establishment of these connections should have triggered the sending
of all gossip to the other peer. So we don't need to send it ourself.

Fixes #454.