### PR TITLE
Don't force -d on docker run

### DIFF
--- a/weave
+++ b/weave
@@ -610,7 +610,7 @@ case "$COMMAND" in
         validate_cidr $CIDR
         shift 1
         create_bridge
-        CONTAINER=$(docker run $DNS_ARG $DNS_SEARCH_ARG -d "$@")
+        CONTAINER=$(docker run $DNS_ARG $DNS_SEARCH_ARG "$@")
         with_container_netns $CONTAINER attach $CIDR >/dev/null
         tell_dns PUT $CONTAINER $CIDR
         echo $CONTAINER


### PR DESCRIPTION
This makes it impossible for CoreOS/SystemD users to run containers as a service that utilize Weave with Restart=always and other flags and makes it where you have to use Type=oneshot and RemainAfterExit=yes, in your SystemD/Fleet unit.  This seems like a strange assumption to make on behalf of the user.