### PR TITLE
Include weave dns information in `weave status`

### DIFF
--- a/nameserver/http.go
+++ b/nameserver/http.go
@@ -17,12 +17,13 @@ func httpErrorAndLog(level *log.Logger, w http.ResponseWriter, msg string,
 	level.Printf("[http] "+logmsg, logargs...)
 }
 
-func ListenHttp(domain string, db Zone, port int) {
+func ListenHttp(version string, domain string, db Zone, port int) {
 
 	router := mux.NewRouter()
 
 	router.Methods("GET").Path("/status").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		io.WriteString(w, "ok")
+		io.WriteString(w, fmt.Sprintln("weave DNS", version))
+		io.WriteString(w, fmt.Sprintln("Serving domain", domain))
 	})
 
 	router.Methods("PUT").Path("/name/{identifier:.+}/{ip:.+}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/nameserver/http.go
+++ b/nameserver/http.go
@@ -1,6 +1,7 @@
 package nameserver
 
 import (
+	"errors"
 	"fmt"
 	"github.com/miekg/dns"
 	. "github.com/zettio/weave/common"
@@ -8,8 +9,17 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"github.com/gorilla/mux"
+	"strings"
 )
+
+// Parse a URL of the form PUT /name/<identifier>/<ip-address>
+func parseUrl(url string) (identifier string, ipaddr string, err error) {
+	parts := strings.Split(url, "/")
+	if len(parts) != 4 {
+		return "", "", errors.New("Unable to parse url: " + url)
+	}
+	return parts[2], parts[3], nil
+}
 
 func httpErrorAndLog(level *log.Logger, w http.ResponseWriter, msg string,
 	status int, logmsg string, logargs ...interface{}) {
@@ -19,75 +29,78 @@ func httpErrorAndLog(level *log.Logger, w http.ResponseWriter, msg string,
 
 func ListenHttp(version string, server *DNSServer, domain string, db Zone, port int) {
 
-	router := mux.NewRouter()
-
-	router.Methods("GET").Path("/status").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		io.WriteString(w, fmt.Sprintln("weave DNS", version))
-		io.WriteString(w, server.Status())
+	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		} else {
+			io.WriteString(w, fmt.Sprintln("weave DNS", version))
+			io.WriteString(w, server.Status())
+		}
 	})
 
-	router.Methods("PUT").Path("/name/{identifier:.+}/{ip:.+}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/name/", func(w http.ResponseWriter, r *http.Request) {
+
 		reqError := func(msg string, logmsg string, logargs ...interface{}) {
-			httpErrorAndLog(Warning, w, msg, http.StatusBadRequest, logmsg, logargs...)
+			httpErrorAndLog(Warning, w, msg, http.StatusBadRequest,
+				logmsg, logargs...)
 		}
 
-		vars := mux.Vars(r)
-		ident := vars["identifier"]
-		ipStr := vars["ip"]
-		name := r.FormValue("fqdn")
+		switch r.Method {
+		case "PUT":
+			ident, ipStr, err := parseUrl(r.URL.Path)
+			name := r.FormValue("fqdn")
+			if ident == "" || ipStr == "" || name == "" {
+				reqError("Invalid request", "Invalid request: %s, %s", r.URL, r.Form)
+				return
+			}
 
-		if name == "" {
-			reqError("Invalid FQDN", "Invalid FQDN in request: %s, %s", r.URL, r.Form)
-			return
-		}
+			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				reqError("Invalid IP", "Invalid IP in request: %s", ipStr)
+				return
+			}
 
-		ip := net.ParseIP(ipStr)
-		if ip == nil {
-			reqError("Invalid IP", "Invalid IP in request: %s", ipStr)
-			return
-		}
+			if dns.IsSubDomain(domain, name) {
+				Info.Printf("[http] Adding %s -> %s", name, ipStr)
+				if err = db.AddRecord(ident, name, ip); err != nil {
+					if _, ok := err.(DuplicateError); !ok {
+						httpErrorAndLog(
+							Error, w, "Internal error", http.StatusInternalServerError,
+							"Unexpected error from DB: %s", err)
+						return
+					} // oh, I already know this. whatever.
+				}
+			} else {
+				Info.Printf("[http] Ignoring name %s, not in %s", name, domain)
+			}
 
-		if dns.IsSubDomain(domain, name) {
-			Info.Printf("[http] Adding %s -> %s", name, ipStr)
-			if err := db.AddRecord(ident, name, ip); err != nil {
-				if _, ok := err.(DuplicateError); !ok {
+		case "DELETE":
+			ident, ipStr, err := parseUrl(r.URL.Path)
+			if ident == "" || ipStr == "" {
+				reqError("Invalid Request", "Invalid request: %s, %s", r.URL, r.Form)
+				return
+			}
+
+			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				reqError("Invalid IP in request", "Invalid IP in request: %s", ipStr)
+				return
+			}
+			Info.Printf("[http] Deleting %s (%s)", ident, ipStr)
+			if err = db.DeleteRecord(ident, ip); err != nil {
+				if _, ok := err.(LookupError); !ok {
 					httpErrorAndLog(
 						Error, w, "Internal error", http.StatusInternalServerError,
 						"Unexpected error from DB: %s", err)
 					return
-				} // oh, I already know this. whatever.
+				}
 			}
-		} else {
-			Info.Printf("[http] Ignoring name %s, not in %s", name, domain)
-		}
-	})
-
-	router.Methods("DELETE").Path("/name/{identifier:.+}/{ip:.+}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqError := func(msg string, logmsg string, logargs ...interface{}) {
-			httpErrorAndLog(Warning, w, msg, http.StatusBadRequest, logmsg, logargs...)
-		}
-
-		vars := mux.Vars(r)
-		ident := vars["identifier"]
-		ipStr := vars["ip"]
-
-		ip := net.ParseIP(ipStr)
-		if ip == nil {
-			reqError("Invalid IP in request", "Invalid IP in request: %s", ipStr)
+		default:
+			msg := "Unexpected http method: " + r.Method
+			reqError(msg, msg)
 			return
 		}
-		Info.Printf("[http] Deleting %s (%s)", ident, ipStr)
-		if err := db.DeleteRecord(ident, ip); err != nil {
-			if _, ok := err.(LookupError); !ok {
-				httpErrorAndLog(
-					Error, w, "Internal error", http.StatusInternalServerError,
-					"Unexpected error from DB: %s", err)
-				return
-			}
-		}
 	})
-
-	http.Handle("/", router)
 
 	address := fmt.Sprintf(":%d", port)
 	if err := http.ListenAndServe(address, nil); err != nil {

--- a/nameserver/http.go
+++ b/nameserver/http.go
@@ -17,7 +17,7 @@ func httpErrorAndLog(level *log.Logger, w http.ResponseWriter, msg string,
 	level.Printf("[http] "+logmsg, logargs...)
 }
 
-func ListenHttp(version string, server *DNSServer, db Zone, port int) {
+func ListenHttp(version string, server *DNSServer, domain string, db Zone, port int) {
 
 	router := mux.NewRouter()
 
@@ -47,7 +47,7 @@ func ListenHttp(version string, server *DNSServer, db Zone, port int) {
 			return
 		}
 
-		if dns.IsSubDomain(server.Domain, name) {
+		if dns.IsSubDomain(domain, name) {
 			Info.Printf("[http] Adding %s -> %s", name, ipStr)
 			if err := db.AddRecord(ident, name, ip); err != nil {
 				if _, ok := err.(DuplicateError); !ok {
@@ -58,7 +58,7 @@ func ListenHttp(version string, server *DNSServer, db Zone, port int) {
 				} // oh, I already know this. whatever.
 			}
 		} else {
-			Info.Printf("[http] Ignoring name %s, not in %s", name, server.Domain)
+			Info.Printf("[http] Ignoring name %s, not in %s", name, domain)
 		}
 	})
 

--- a/nameserver/http.go
+++ b/nameserver/http.go
@@ -24,6 +24,7 @@ func ListenHttp(version string, domain string, db Zone, port int) {
 	router.Methods("GET").Path("/status").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, fmt.Sprintln("weave DNS", version))
 		io.WriteString(w, fmt.Sprintln("Serving domain", domain))
+		io.WriteString(w, db.Status())
 	})
 
 	router.Methods("PUT").Path("/name/{identifier:.+}/{ip:.+}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/nameserver/http.go
+++ b/nameserver/http.go
@@ -1,7 +1,6 @@
 package nameserver
 
 import (
-	"errors"
 	"fmt"
 	"github.com/miekg/dns"
 	. "github.com/zettio/weave/common"
@@ -9,17 +8,8 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"strings"
+	"github.com/gorilla/mux"
 )
-
-// Parse a URL of the form PUT /name/<identifier>/<ip-address>
-func parseUrl(url string) (identifier string, ipaddr string, err error) {
-	parts := strings.Split(url, "/")
-	if len(parts) != 4 {
-		return "", "", errors.New("Unable to parse url: " + url)
-	}
-	return parts[2], parts[3], nil
-}
 
 func httpErrorAndLog(level *log.Logger, w http.ResponseWriter, msg string,
 	status int, logmsg string, logargs ...interface{}) {
@@ -29,77 +19,74 @@ func httpErrorAndLog(level *log.Logger, w http.ResponseWriter, msg string,
 
 func ListenHttp(domain string, db Zone, port int) {
 
-	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		} else {
-			io.WriteString(w, "ok")
-		}
+	router := mux.NewRouter()
+
+	router.Methods("GET").Path("/status").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "ok")
 	})
 
-	http.HandleFunc("/name/", func(w http.ResponseWriter, r *http.Request) {
-
+	router.Methods("PUT").Path("/name/{identifier:.+}/{ip:.+}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqError := func(msg string, logmsg string, logargs ...interface{}) {
-			httpErrorAndLog(Warning, w, msg, http.StatusBadRequest,
-				logmsg, logargs...)
+			httpErrorAndLog(Warning, w, msg, http.StatusBadRequest, logmsg, logargs...)
 		}
 
-		switch r.Method {
-		case "PUT":
-			ident, ipStr, err := parseUrl(r.URL.Path)
-			name := r.FormValue("fqdn")
-			if ident == "" || ipStr == "" || name == "" {
-				reqError("Invalid request", "Invalid request: %s, %s", r.URL, r.Form)
-				return
-			}
+		vars := mux.Vars(r)
+		ident := vars["identifier"]
+		ipStr := vars["ip"]
+		name := r.FormValue("fqdn")
 
-			ip := net.ParseIP(ipStr)
-			if ip == nil {
-				reqError("Invalid IP", "Invalid IP in request: %s", ipStr)
-				return
-			}
+		if name == "" {
+			reqError("Invalid FQDN", "Invalid FQDN in request: %s, %s", r.URL, r.Form)
+			return
+		}
 
-			if dns.IsSubDomain(domain, name) {
-				Info.Printf("[http] Adding %s -> %s", name, ipStr)
-				if err = db.AddRecord(ident, name, ip); err != nil {
-					if _, ok := err.(DuplicateError); !ok {
-						httpErrorAndLog(
-							Error, w, "Internal error", http.StatusInternalServerError,
-							"Unexpected error from DB: %s", err)
-						return
-					} // oh, I already know this. whatever.
-				}
-			} else {
-				Info.Printf("[http] Ignoring name %s, not in %s", name, domain)
-			}
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			reqError("Invalid IP", "Invalid IP in request: %s", ipStr)
+			return
+		}
 
-		case "DELETE":
-			ident, ipStr, err := parseUrl(r.URL.Path)
-			if ident == "" || ipStr == "" {
-				reqError("Invalid Request", "Invalid request: %s, %s", r.URL, r.Form)
-				return
-			}
-
-			ip := net.ParseIP(ipStr)
-			if ip == nil {
-				reqError("Invalid IP in request", "Invalid IP in request: %s", ipStr)
-				return
-			}
-			Info.Printf("[http] Deleting %s (%s)", ident, ipStr)
-			if err = db.DeleteRecord(ident, ip); err != nil {
-				if _, ok := err.(LookupError); !ok {
+		if dns.IsSubDomain(domain, name) {
+			Info.Printf("[http] Adding %s -> %s", name, ipStr)
+			if err := db.AddRecord(ident, name, ip); err != nil {
+				if _, ok := err.(DuplicateError); !ok {
 					httpErrorAndLog(
 						Error, w, "Internal error", http.StatusInternalServerError,
 						"Unexpected error from DB: %s", err)
 					return
-				}
+				} // oh, I already know this. whatever.
 			}
-		default:
-			msg := "Unexpected http method: " + r.Method
-			reqError(msg, msg)
-			return
+		} else {
+			Info.Printf("[http] Ignoring name %s, not in %s", name, domain)
 		}
 	})
+
+	router.Methods("DELETE").Path("/name/{identifier:.+}/{ip:.+}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqError := func(msg string, logmsg string, logargs ...interface{}) {
+			httpErrorAndLog(Warning, w, msg, http.StatusBadRequest, logmsg, logargs...)
+		}
+
+		vars := mux.Vars(r)
+		ident := vars["identifier"]
+		ipStr := vars["ip"]
+
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			reqError("Invalid IP in request", "Invalid IP in request: %s", ipStr)
+			return
+		}
+		Info.Printf("[http] Deleting %s (%s)", ident, ipStr)
+		if err := db.DeleteRecord(ident, ip); err != nil {
+			if _, ok := err.(LookupError); !ok {
+				httpErrorAndLog(
+					Error, w, "Internal error", http.StatusInternalServerError,
+					"Unexpected error from DB: %s", err)
+				return
+			}
+		}
+	})
+
+	http.Handle("/", router)
 
 	address := fmt.Sprintf(":%d", port)
 	if err := http.ListenAndServe(address, nil); err != nil {

--- a/nameserver/http_test.go
+++ b/nameserver/http_test.go
@@ -30,7 +30,7 @@ func TestHttp(t *testing.T) {
 	var zone = new(ZoneDb)
 	port := rand.Intn(10000) + 32768
 	fmt.Println("Http test on port", port)
-	go ListenHttp(testDomain, zone, port)
+	go ListenHttp("", nil, testDomain, zone, port)
 
 	time.Sleep(100 * time.Millisecond) // Allow for http server to get going
 

--- a/nameserver/server.go
+++ b/nameserver/server.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/zettio/weave/common"
 	"net"
 	"sync"
+	"bytes"
 )
 
 const (
@@ -140,6 +141,17 @@ func (s *DNSServer) Start() error {
 
 	Info.Printf("WeaveDNS server exiting...")
 	return nil
+}
+
+// Return status string
+func (s *DNSServer) Status() string {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintln("Local domain", s.Domain))
+	buf.WriteString(fmt.Sprintln("Listen address", s.ListenAddr))
+	buf.WriteString(fmt.Sprintln("mDNS interface", s.iface))
+	buf.WriteString(fmt.Sprintln("Fallback DNS config", s.upstream))
+	buf.WriteString(fmt.Sprintf("Zone database:\n%s", s.zone))
+	return buf.String()
 }
 
 // Perform a graceful shutdown

--- a/nameserver/zone.go
+++ b/nameserver/zone.go
@@ -68,7 +68,7 @@ func (zone *ZoneDb) String() string {
 	defer zone.mx.RUnlock()
 	var buf bytes.Buffer
 	for _, r := range zone.recs {
-		buf.WriteString(fmt.Sprintf("%s %s %v\n", r.Ident, r.IP, r.Name))
+		buf.WriteString(fmt.Sprintf("%.12s %s %v\n", r.Ident, r.IP, r.Name))
 	}
 	return buf.String()
 }

--- a/nameserver/zone.go
+++ b/nameserver/zone.go
@@ -22,7 +22,6 @@ type Lookup interface {
 }
 
 type Zone interface {
-	Status() string
 	AddRecord(ident string, name string, ip net.IP) error
 	DeleteRecord(ident string, ip net.IP) error
 	DeleteRecordsFor(ident string) error
@@ -64,11 +63,10 @@ func (zone *ZoneDb) indexOf(match func(Record) bool) int {
 	return -1
 }
 
-func (zone *ZoneDb) Status() string {
+func (zone *ZoneDb) String() string {
 	zone.mx.RLock()
 	defer zone.mx.RUnlock()
 	var buf bytes.Buffer
-	buf.WriteString("Records:\n")
 	for _, r := range zone.recs {
 		buf.WriteString(fmt.Sprintf("%s %s %v\n", r.Ident, r.IP, r.Name))
 	}

--- a/nameserver/zone.go
+++ b/nameserver/zone.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/zettio/weave/common"
 	"net"
 	"sync"
+	"bytes"
+	"fmt"
 )
 
 const (
@@ -20,6 +22,7 @@ type Lookup interface {
 }
 
 type Zone interface {
+	Status() string
 	AddRecord(ident string, name string, ip net.IP) error
 	DeleteRecord(ident string, ip net.IP) error
 	DeleteRecordsFor(ident string) error
@@ -59,6 +62,17 @@ func (zone *ZoneDb) indexOf(match func(Record) bool) int {
 		}
 	}
 	return -1
+}
+
+func (zone *ZoneDb) Status() string {
+	zone.mx.RLock()
+	defer zone.mx.RUnlock()
+	var buf bytes.Buffer
+	buf.WriteString("Records:\n")
+	for _, r := range zone.recs {
+		buf.WriteString(fmt.Sprintf("%s %s %v\n", r.Ident, r.IP, r.Name))
+	}
+	return buf.String()
 }
 
 func (zone *ZoneDb) LookupName(name string) (net.IP, error) {

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -51,7 +51,7 @@ The command
 
     weave status
 
-reports on the current status of the weave router.
+reports on the current status of the weave router and DNS.
 
 This produces output like:
 
@@ -80,6 +80,8 @@ broadcast:
 7a:16:dd:5b:83:de -> []
 Reconnects:
 192.168.32.1:6783 (next try at 2014-10-23 16:39:50.585932102 +0000 UTC)
+
+weavedns container is not present; have you launched it?
 ````
 
 The terms used here are explained further at
@@ -117,10 +119,15 @@ weave network is not fully connected.  See the
 [architecture documentation](https://raw.githubusercontent.com/zettio/weave/master/docs/architecture.txt)
 for a full explanation.
 
-Finally, 'Reconnects' lists peers that this router is aware of, but is
+The 'Reconnects' section lists peers that this router is aware of, but is
 not currently connected to.  Each line contains some information about
 whether it is attempting to connect or is waiting for a while before
 connecting again.
+
+Finally, status information from weave DNS is included. In this example,
+the DNS container has not been launched so no status information is
+available (see the [WeaveDNS README](https://github.com/zettio/weave/blob/master/weavedns/README.md)
+for more information).
 
 ### <a name="list-attached-containers"></a>List attached containers
 

--- a/weave
+++ b/weave
@@ -556,6 +556,7 @@ case "$COMMAND" in
         ;;
     status)
         http_call $CONTAINER_NAME $HTTP_PORT GET /status
+        http_call $DNS_CONTAINER_NAME $DNS_HTTP_PORT GET /status
         ;;
     ps)
         [ $# -eq 0 ] || usage

--- a/weave
+++ b/weave
@@ -555,7 +555,7 @@ case "$COMMAND" in
         http_call $CONTAINER_NAME $HTTP_PORT POST /connect -d "peer=$1"
         ;;
     status)
-        http_call $CONTAINER_NAME $HTTP_PORT GET /status
+        http_call $CONTAINER_NAME $HTTP_PORT GET /status || true
         echo
         http_call $DNS_CONTAINER_NAME $DNS_HTTP_PORT GET /status
         ;;

--- a/weave
+++ b/weave
@@ -555,10 +555,9 @@ case "$COMMAND" in
         http_call $CONTAINER_NAME $HTTP_PORT POST /connect -d "peer=$1"
         ;;
     status)
-        if http_call $CONTAINER_NAME $HTTP_PORT GET /status; then ROUTER_UP=true; else ROUTER_UP=false; fi
+        http_call $CONTAINER_NAME $HTTP_PORT GET /status || true
         echo
-        if http_call $DNS_CONTAINER_NAME $DNS_HTTP_PORT GET /status; then DNS_UP=true; else DNS_UP=false; fi
-        $ROUTER_UP && $DNS_UP
+        http_call $DNS_CONTAINER_NAME $DNS_HTTP_PORT GET /status || true
         ;;
     ps)
         [ $# -eq 0 ] || usage

--- a/weave
+++ b/weave
@@ -556,6 +556,7 @@ case "$COMMAND" in
         ;;
     status)
         http_call $CONTAINER_NAME $HTTP_PORT GET /status
+        echo
         http_call $DNS_CONTAINER_NAME $DNS_HTTP_PORT GET /status
         ;;
     ps)

--- a/weave
+++ b/weave
@@ -555,9 +555,10 @@ case "$COMMAND" in
         http_call $CONTAINER_NAME $HTTP_PORT POST /connect -d "peer=$1"
         ;;
     status)
-        http_call $CONTAINER_NAME $HTTP_PORT GET /status || true
+        if http_call $CONTAINER_NAME $HTTP_PORT GET /status; then ROUTER_UP=true; else ROUTER_UP=false; fi
         echo
-        http_call $DNS_CONTAINER_NAME $DNS_HTTP_PORT GET /status
+        if http_call $DNS_CONTAINER_NAME $DNS_HTTP_PORT GET /status; then DNS_UP=true; else DNS_UP=false; fi
+        $ROUTER_UP && $DNS_UP
         ;;
     ps)
         [ $# -eq 0 ] || usage

--- a/weavedns/README.md
+++ b/weavedns/README.md
@@ -177,6 +177,61 @@ $ dns_ip=$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' weavedns)
 $ curl -X DELETE "http://$dns_ip:6785/name/$shell2/10.2.1.27"
 ```
 
+## Troubleshooting
+
+The command
+
+    weave status
+
+reports on the current status of the weave router and DNS:
+
+````
+weave router git-8f675f15c0b5
+Encryption off
+Our name is 7a:17:ee:72:ef:9c (ubuntu-14)
+Sniffing traffic on &{42 65535 ethwe 36:59:20:e5:a4:64 up|broadcast|multicast}
+MACs:
+32:ff:76:23:d3:f1 -> 7a:17:ee:72:ef:9c (2015-03-18 12:52:37.329938912 +0000 UTC)
+36:59:20:e5:a4:64 -> 7a:17:ee:72:ef:9c (2015-03-18 12:52:36.495276933 +0000 UTC)
+Peers:
+Peer 7a:17:ee:72:ef:9c (ubuntu-14) (v0) (UID 11664962155092689251)
+Routes:
+unicast:
+7a:17:ee:72:ef:9c -> 00:00:00:00:00:00
+broadcast:
+7a:17:ee:72:ef:9c -> []
+Reconnects:
+
+weave DNS git-8f675f15c0b5
+Local domain weave.local.
+Listen address :53
+mDNS interface &{26 65535 ethwe fa:b6:b1:85:ac:9b up|broadcast|multicast}
+Fallback DNS config &{[66.28.0.45 8.8.8.8] [] 53 1 5 2}
+Zone database:
+710978857a888f3d9a126452bf58db12d3aeb4f6bf7f076eb639bc714aaa1f4b 10.2.1.26 wiff.weave.local.
+e8d85b1dcdb15053c8ca5a747812a886125a9150b060a66b66fe7d18ecdad762 10.2.1.27 waff.weave.local.
+26bd05f9a0cbef1d57425562126a725383027a23f7368518ad5162e1cb958c17 10.2.1.28 ping.weave.local.
+1ab0e8b17c391733057a1abdfd2c7842c15b415775571402c328d2735a46e323 10.2.1.29 pong.weave.local.
+````
+
+The first section covers the router; see the troubleshooting guide in
+the main documentation for more detail.
+
+The second section is pertinent to weaveDNS, and includes:
+
+* The local domain suffix which is being served
+* The address on which the DNS server is listening
+* The interface being used for multicast DNS
+* The fallback DNS which will be used to resolve non local names
+* The names known to this host's DNS server. Each entry comprises the container ID, IP address and it's fully qualified domain name
+
+In the case where weaveDNS has not been launched, the second section of `weave status`
+will report the following:
+
+````
+weavedns container is not present; have you launched it?
+````
+
 ## Present limitations
 
  * The server will not know about restarted containers, but if you

--- a/weavedns/README.md
+++ b/weavedns/README.md
@@ -195,10 +195,10 @@ Listen address :53
 mDNS interface &{26 65535 ethwe fa:b6:b1:85:ac:9b up|broadcast|multicast}
 Fallback DNS config &{[66.28.0.45 8.8.8.8] [] 53 1 5 2}
 Zone database:
-710978857a888f3d9a126452bf58db12d3aeb4f6bf7f076eb639bc714aaa1f4b 10.2.1.26 wiff.weave.local.
-e8d85b1dcdb15053c8ca5a747812a886125a9150b060a66b66fe7d18ecdad762 10.2.1.27 waff.weave.local.
-26bd05f9a0cbef1d57425562126a725383027a23f7368518ad5162e1cb958c17 10.2.1.28 ping.weave.local.
-1ab0e8b17c391733057a1abdfd2c7842c15b415775571402c328d2735a46e323 10.2.1.29 pong.weave.local.
+710978857a88 10.2.1.26 wiff.weave.local.
+e8d85b1dcdb1 10.2.1.27 waff.weave.local.
+26bd05f9a0cb 10.2.1.28 ping.weave.local.
+1ab0e8b17c39 10.2.1.29 pong.weave.local.
 ````
 
 The first section covers the router; see the troubleshooting guide in

--- a/weavedns/README.md
+++ b/weavedns/README.md
@@ -187,20 +187,7 @@ reports on the current status of the weave router and DNS:
 
 ````
 weave router git-8f675f15c0b5
-Encryption off
-Our name is 7a:17:ee:72:ef:9c (ubuntu-14)
-Sniffing traffic on &{42 65535 ethwe 36:59:20:e5:a4:64 up|broadcast|multicast}
-MACs:
-32:ff:76:23:d3:f1 -> 7a:17:ee:72:ef:9c (2015-03-18 12:52:37.329938912 +0000 UTC)
-36:59:20:e5:a4:64 -> 7a:17:ee:72:ef:9c (2015-03-18 12:52:36.495276933 +0000 UTC)
-Peers:
-Peer 7a:17:ee:72:ef:9c (ubuntu-14) (v0) (UID 11664962155092689251)
-Routes:
-unicast:
-7a:17:ee:72:ef:9c -> 00:00:00:00:00:00
-broadcast:
-7a:17:ee:72:ef:9c -> []
-Reconnects:
+...
 
 weave DNS git-8f675f15c0b5
 Local domain weave.local.
@@ -223,14 +210,7 @@ The second section is pertinent to weaveDNS, and includes:
 * The address on which the DNS server is listening
 * The interface being used for multicast DNS
 * The fallback DNS which will be used to resolve non local names
-* The names known to this host's DNS server. Each entry comprises the container ID, IP address and it's fully qualified domain name
-
-In the case where weaveDNS has not been launched, the second section of `weave status`
-will report the following:
-
-````
-weavedns container is not present; have you launched it?
-````
+* The names known to the local weaveDNS server. Each entry comprises the container ID, IP address and its fully qualified domain name
 
 ## Present limitations
 

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -87,7 +87,7 @@ func main() {
 	if err != nil {
 		Error.Fatal("Failed to initialize the WeaveDNS server", err)
 	}
-	go weavedns.ListenHttp(version, srv, zone, httpPort)
+	go weavedns.ListenHttp(version, srv, localDomain, zone, httpPort)
 	err = srv.Start()
 	if err != nil {
 		Error.Fatal("Failed to start the WeaveDNS server", err)

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -83,7 +83,7 @@ func main() {
 		Debug.Printf("DNS fallback at %s:%s", fallbackHost, fallbackPort)
 	}
 
-	go weavedns.ListenHttp(localDomain, zone, httpPort)
+	go weavedns.ListenHttp(version, localDomain, zone, httpPort)
 	srv, err := weavedns.NewDNSServer(srvConfig, zone, iface)
 	if err != nil {
 		Error.Fatal("Failed to initialize the WeaveDNS server", err)

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -83,11 +83,11 @@ func main() {
 		Debug.Printf("DNS fallback at %s:%s", fallbackHost, fallbackPort)
 	}
 
-	go weavedns.ListenHttp(version, localDomain, zone, httpPort)
 	srv, err := weavedns.NewDNSServer(srvConfig, zone, iface)
 	if err != nil {
 		Error.Fatal("Failed to initialize the WeaveDNS server", err)
 	}
+	go weavedns.ListenHttp(version, srv, zone, httpPort)
 	err = srv.Start()
 	if err != nil {
 		Error.Fatal("Failed to start the WeaveDNS server", err)


### PR DESCRIPTION
Addresses #237 - Add weavedns status to `weave status`.

Sample output:

````
~/weave$ sudo ./weave status
weave router git-9eeec2fa4835
Encryption off
Our name is 7a:6e:b1:a9:28:4d (ubuntu-14)
Sniffing traffic on &{12 65535 ethwe 6e:54:91:56:f2:9a up|broadcast|multicast}
MACs:
Peers:
Peer 7a:6e:b1:a9:28:4d (ubuntu-14) (v0) (UID 17345352114913090227)
Routes:
unicast:
7a:6e:b1:a9:28:4d -> 00:00:00:00:00:00
broadcast:
7a:6e:b1:a9:28:4d -> []
Reconnects:

weave DNS git-6f57774d1516
Local domain weave.local.
Listen address :53
mDNS interface &{112 65535 ethwe ea:43:db:f3:c3:3d up|broadcast|multicast}
Fallback DNS config &{[10.0.2.3] [] 53 1 5 2}
Zone database:
2aca5f21b82b1898f7e9bb6919b77a56999e6c4b7c292f3f88c8cec3a7db72b7 10.2.1.4 waff.weave.local.
5962267f738d8db93d2b119968dc881014a82a30db57b96f5cb786fd911fc334 10.2.1.3 wiff.weave.local.
542a24da39383cf6ca64ca67dd7560c3d4ef145a04b1decc8cd5d082a17aa3db 10.2.1.2 pong.weave.local.
1226cbc0bee34c57373b65b63a42c6f47449e29388df2fd5ed7aebddf9fa0110 10.2.1.1 ping.weave.local.
````

Implementation notes:
* As per in-person discussion with @squaremo and @rade this is implemented by `/status` returning a human readable `text/plain` document to mirror the current router REST API
* Suggested HEAD optimisation has been omitted due to `curl -X` behaviour