### PR TITLE
simplify actors

### DIFF
--- a/router/gossip_test.go
+++ b/router/gossip_test.go
@@ -21,7 +21,7 @@ type mockChannelConnection struct {
 func NewTestRouter(name PeerName) *Router {
 	router := NewRouter(nil, name, "", nil, 10, 1024, nil)
 	router.ConnectionMaker.queryChan = make(chan *ConnectionMakerInteraction, ChannelSize)
-	router.Routes.queryChan = make(chan *Interaction, ChannelSize)
+	router.Routes.actionChan = make(chan RoutesAction, ChannelSize)
 	return router
 }
 

--- a/router/gossip_test.go
+++ b/router/gossip_test.go
@@ -20,7 +20,7 @@ type mockChannelConnection struct {
 // channels when Router.OnGossip() calls async methods.
 func NewTestRouter(name PeerName) *Router {
 	router := NewRouter(nil, name, "", nil, 10, 1024, nil)
-	router.ConnectionMaker.queryChan = make(chan *ConnectionMakerInteraction, ChannelSize)
+	router.ConnectionMaker.actionChan = make(chan ConnectionMakerAction, ChannelSize)
 	router.Routes.actionChan = make(chan RoutesAction, ChannelSize)
 	return router
 }

--- a/router/utils.go
+++ b/router/utils.go
@@ -10,11 +10,6 @@ import (
 	"net"
 )
 
-type Interaction struct {
-	code       int
-	resultChan chan<- interface{}
-}
-
 func checkFatal(e error) {
 	if e != nil {
 		log.Fatal(e)


### PR DESCRIPTION
Instead of actor client methods passing data to the server via the actor's channel, and the server in turn invoking server methods with that data, we get the client methods to pass a closure of the server method via the actor's channel. This reduces boilerplate a fair bit.

Closes #475.