### PR TITLE
Setup Travis CI for Weave.  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+sudo: false
+go:
+  - 1.4
+
+addons:
+  apt:
+    packages:
+    - libpcap-dev
+
+install: 
+  - go clean -i net
+  - go install -tags netgo std
+  - make travis
+
+script: make tests

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PUBLISH=publish_weave publish_weavedns publish_weaveexec
 
 .DEFAULT: all
-.PHONY: all update tests publish $(PUBLISH) clean prerequisites build
+.PHONY: all update tests publish $(PUBLISH) clean prerequisites build travis
 
 # If you can use docker without being root, you can do "make SUDO="
 SUDO=sudo
@@ -22,6 +22,8 @@ DOCKER_DISTRIB=weaveexec/docker-$(WEAVEEXEC_DOCKER_VERSION).tgz
 DOCKER_DISTRIB_URL=https://get.docker.com/builds/Linux/x86_64/docker-$(WEAVEEXEC_DOCKER_VERSION).tgz
 
 all: $(WEAVER_EXPORT) $(WEAVEDNS_EXPORT) $(WEAVEEXEC_EXPORT)
+
+travis: $(WEAVER_EXE) $(WEAVEDNS_EXE)
 
 update:
 	go get -u -f -v -tags -netgo ./$(dir $(WEAVER_EXE)) ./$(dir $(WEAVEDNS_EXE))

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Weave - the Docker network
 
+[![Build Status](https://travis-ci.org/zettio/weave.svg?branch=master)](https://travis-ci.org/zettio/weave)
+
 Weave creates a virtual network that connects Docker containers
 deployed across multiple hosts.
 


### PR DESCRIPTION
- Add .travis.yml
- Add target to makefile which doesn't use docker (can't use docker on travis right now)
- Add build image to readme.

NB sudo: false is to get their faster, docker based build.