### PR TITLE
Move away from recursive go test, as it cannot output a merged coverage profile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ _testmain.go
 *.exe
 *.test
 *.prof
+profile.cov
+coverage.html
 
 # Emacs backup files
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,9 @@ install:
   - go install -tags netgo std
   - make travis
 
-script: make tests
+script:
+  - make tests
+
+after_success:
+  - go get github.com/mattn/goveralls
+  - $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,15 @@ $(DOCKER_DISTRIB):
 	curl -o $(DOCKER_DISTRIB) $(DOCKER_DISTRIB_URL)
 
 tests:
-	go test -cover -tags netgo ./...
+	echo "mode: count" > profile.cov
+	for dir in $$(find . -type f -name '*_test.go' | xargs -n1 dirname | sort -u); do \
+	    go test -tags netgo -covermode=count -coverprofile=$$dir/profile.tmp $$dir;       \
+	    if [ -f $$dir/profile.tmp ]; then                                                 \
+	        cat $$dir/profile.tmp | tail -n +2 >> profile.cov;                            \
+	        rm $$dir/profile.tmp;                                                         \
+	    fi                                                                                \
+	done
+	go tool cover -html=profile.cov -o=coverage.html
 
 $(PUBLISH): publish_%:
 	$(SUDO) docker tag -f $(DOCKERHUB_USER)/$* $(DOCKERHUB_USER)/$*:$(WEAVE_VERSION)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Weave - the Docker network
 
-[![Build Status](https://travis-ci.org/zettio/weave.svg?branch=master)](https://travis-ci.org/zettio/weave)
+[![Build Status](https://travis-ci.org/zettio/weave.svg?branch=master)](https://travis-ci.org/zettio/weave) [![Coverage Status](https://coveralls.io/repos/zettio/weave/badge.svg)](https://coveralls.io/r/zettio/weave)
 
 Weave creates a virtual network that connects Docker containers
 deployed across multiple hosts.


### PR DESCRIPTION
- Update said profile to coveralls.io
- Add badge to readme