### PR TITLE
lower topology update gossip complexity

### DIFF
--- a/router/gossip.go
+++ b/router/gossip.go
@@ -20,13 +20,15 @@ type Gossip interface {
 	// specific message from one peer to another
 	// intermediate peers relay it using unicast topology.
 	GossipUnicast(dstPeerName PeerName, msg []byte) error
-	// send a message to every peer, relayed using broadcast topology.
-	GossipBroadcast(msg []byte) error
+	// send gossip to every peer, relayed using broadcast topology.
+	GossipBroadcast(update GossipData) error
 }
 
 type Gossiper interface {
 	OnGossipUnicast(sender PeerName, msg []byte) error
-	OnGossipBroadcast(msg []byte) error
+	// merge received data into state and return a representation of
+	// the received data, for further propagation
+	OnGossipBroadcast(update []byte) (GossipData, error)
 	// return state of everything we know; gets called periodically
 	Gossip() GossipData
 	// merge received data into state and return "everything new I've
@@ -150,15 +152,16 @@ func (c *GossipChannel) deliverUnicast(srcName PeerName, origPayload []byte, dec
 	return c.gossiper.OnGossipUnicast(srcName, payload)
 }
 
-func (c *GossipChannel) deliverBroadcast(srcName PeerName, origPayload []byte, dec *gob.Decoder) error {
+func (c *GossipChannel) deliverBroadcast(srcName PeerName, _ []byte, dec *gob.Decoder) error {
 	var payload []byte
 	if err := dec.Decode(&payload); err != nil {
 		return err
 	}
-	if err := c.gossiper.OnGossipBroadcast(payload); err != nil {
+	data, err := c.gossiper.OnGossipBroadcast(payload)
+	if err != nil || data == nil {
 		return err
 	}
-	return c.relayBroadcast(srcName, origPayload)
+	return c.relayBroadcast(srcName, data)
 }
 
 func (c *GossipChannel) deliver(_ PeerName, _ []byte, dec *gob.Decoder) error {
@@ -214,8 +217,8 @@ func (c *GossipChannel) GossipUnicast(dstPeerName PeerName, msg []byte) error {
 	return c.relayUnicast(dstPeerName, GobEncode(c.hash, c.ourself.Name, dstPeerName, msg))
 }
 
-func (c *GossipChannel) GossipBroadcast(msg []byte) error {
-	return c.relayBroadcast(c.ourself.Name, GobEncode(c.hash, c.ourself.Name, msg))
+func (c *GossipChannel) GossipBroadcast(update GossipData) error {
+	return c.relayBroadcast(c.ourself.Name, update)
 }
 
 func (c *GossipChannel) relayUnicast(dstPeerName PeerName, buf []byte) error {
@@ -229,12 +232,12 @@ func (c *GossipChannel) relayUnicast(dstPeerName PeerName, buf []byte) error {
 	return nil
 }
 
-func (c *GossipChannel) relayBroadcast(srcName PeerName, buf []byte) error {
+func (c *GossipChannel) relayBroadcast(srcName PeerName, update GossipData) error {
 	nextHops := c.ourself.Router.Routes.BroadcastAll(srcName)
 	if len(nextHops) == 0 {
 		return nil
 	}
-	protocolMsg := ProtocolMsg{ProtocolGossipBroadcast, buf}
+	protocolMsg := ProtocolMsg{ProtocolGossipBroadcast, GobEncode(c.hash, srcName, update.Encode())}
 	// FIXME a single blocked connection can stall us
 	for _, conn := range c.ourself.ConnectionsTo(nextHops) {
 		conn.(ProtocolSender).SendProtocolMsg(protocolMsg)

--- a/router/gossip.go
+++ b/router/gossip.go
@@ -269,6 +269,7 @@ func (c *GossipChannel) relayBroadcast(srcName PeerName, update GossipData) erro
 }
 
 func (c *GossipChannel) sendBroadcast(srcName PeerName, update GossipData) {
+	c.ourself.Router.Routes.EnsureRecalculated()
 	nextHops := c.ourself.Router.Routes.BroadcastAll(srcName)
 	if len(nextHops) == 0 {
 		return

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -241,14 +241,7 @@ func (peer *LocalPeer) handleDeleteConnection(conn Connection) {
 
 func (peer *LocalPeer) broadcastPeerUpdate(peers ...*Peer) {
 	peer.Router.Routes.Recalculate()
-	// TODO We should just be invoking TopologyGossip.GossipBroadcast
-	// here, but route calculation is asynchronous and in this
-	// particular case would likely result in the broadcast not
-	// reaching all peers. So instead we slightly break the Gossip
-	// abstraction (hence the cast) and send a regular update. This is
-	// less efficient though since it will almost certainly reach
-	// peers more than once.
-	peer.Router.TopologyGossip.(*GossipChannel).Send(NewTopologyGossipData(peer.Router.Peers, append(peers, peer.Peer)...))
+	peer.Router.TopologyGossip.GossipBroadcast(NewTopologyGossipData(peer.Router.Peers, append(peers, peer.Peer)...))
 }
 
 func (peer *LocalPeer) checkConnectionLimit() error {

--- a/router/protocol.go
+++ b/router/protocol.go
@@ -2,7 +2,7 @@ package router
 
 const (
 	Protocol        = "weave"
-	ProtocolVersion = 14
+	ProtocolVersion = 15
 )
 
 type ProtocolTag byte

--- a/router/router.go
+++ b/router/router.go
@@ -377,8 +377,8 @@ func (router *Router) OnGossipUnicast(sender PeerName, msg []byte) error {
 	return fmt.Errorf("unexpected topology gossip unicast: %v", msg)
 }
 
-func (router *Router) OnGossipBroadcast(msg []byte) error {
-	return fmt.Errorf("unexpected topology gossip broadcast: %v", msg)
+func (router *Router) OnGossipBroadcast(update []byte) (GossipData, error) {
+	return nil, fmt.Errorf("unexpected topology gossip broadcast: %v", update)
 }
 
 func (router *Router) Gossip() GossipData {

--- a/router/router.go
+++ b/router/router.go
@@ -378,7 +378,11 @@ func (router *Router) OnGossipUnicast(sender PeerName, msg []byte) error {
 }
 
 func (router *Router) OnGossipBroadcast(update []byte) (GossipData, error) {
-	return nil, fmt.Errorf("unexpected topology gossip broadcast: %v", update)
+	origUpdate, _, err := router.applyTopologyUpdate(update)
+	if err != nil || len(origUpdate) == 0 {
+		return nil, err
+	}
+	return &TopologyGossipData{peers: router.Peers, update: origUpdate}, nil
 }
 
 func (router *Router) Gossip() GossipData {


### PR DESCRIPTION
Transmit topology updates via gossip broadcast instead of the "send to all neighbours" periodic gossip mechanism.

This requires the following changes:

1. make `Gossip.GossipBroadcast` operate on `GossipData`. We need this so we can perform accumulation (see below). It also gives the opportunity to update data as we relay it, which is an optimisation.
2. add "representation of received update" to return of `Peers.ApplyUpdate`. We need this so we can perform the aforementioned data updating for when relaying topology gossip.
3. use `GossipSender`s for `GossipBroadcast`. Depends on 1. We need this so `GossipBroadcast` becomes properly async, which is required if we want to use it for topology gossip - in order to avoid deadlocks w/o spawning a unbounded number of goroutines. It is also a great optimisation since `GossipData` is accumulated and sent in one go. Note that there is one `GossipSender` per broadcast source since that is the largest granularity at which accumulation is possible. As with the existing `GossipSender`s, we need a way to GC stale entries - in this case for broadcast source peers that have disappeared.
4. introduce `Routes.EnsureRecalculated`. We need this so that when topology gossip uses `GossipBroadcast`, we ensure the broadcast routes are up to date wrt the latest topology.
5. Switch to use `Gossip.GossipBroadcast` for topology updates. Depends on 1,2,3,4.

Closes #514.